### PR TITLE
feat(proxy): Add support for a cert storage

### DIFF
--- a/internal/proxy/cert_storage.go
+++ b/internal/proxy/cert_storage.go
@@ -1,0 +1,37 @@
+package proxy
+
+import (
+	"crypto/tls"
+	"sync"
+)
+
+type CertStorage struct {
+	certs map[string]*tls.Certificate
+	mtx   sync.RWMutex
+}
+
+func (cs *CertStorage) Fetch(hostname string, gen func() (*tls.Certificate, error)) (*tls.Certificate, error) {
+	cs.mtx.RLock()
+	cert, ok := cs.certs[hostname]
+	cs.mtx.RUnlock()
+	if ok {
+		return cert, nil
+	}
+
+	cert, err := gen()
+	if err != nil {
+		return nil, err
+	}
+
+	cs.mtx.Lock()
+	cs.certs[hostname] = cert
+	cs.mtx.Unlock()
+
+	return cert, nil
+}
+
+func NewCertStorage() *CertStorage {
+	return &CertStorage{
+		certs: make(map[string]*tls.Certificate),
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -95,6 +95,7 @@ func (ps *ProxyServer) getProxy() *Proxy {
 }
 
 func (ps *ProxyServer) Listen() {
+	ps.goProxy.CertStore = NewCertStorage()
 	ps.setUpHandlers()
 	time.Sleep(500 * time.Millisecond)
 


### PR DESCRIPTION
When doing a lot of requests using rota, the CPU usage was insanely high, this is due to goproxy generating a new certificate on each request for the domain requested.

To solve this I just implemented this simple example from the goproxy repo: https://github.com/elazarl/goproxy/tree/master/examples/certstorage

References: https://github.com/elazarl/goproxy/issues/430

Feel free to close it if you want to implement it in your own way. You can try it by pulling https://git.nadeko.net/Fijxu/-/packages/container/rota/cert-storage ( `docker pull git.nadeko.net/fijxu/rota:cert-storage` )