### PR TITLE
Add support for follow redirect and custom host

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Example configuration file can be found in [config.yml](config.yml)
 * `proxy_file`: Path to the proxy file
 * `file_watch`: Watch for file changes and reload proxies
 * `proxy`: Proxy configurations
+  - `host`: Proxy server host, leaving it empty will bind to all network interfaces
   - `port`: Proxy server port
   - `authentication`: Authentication configurations
     - `enabled`: Enable basic authentication
@@ -81,6 +82,7 @@ Example configuration file can be found in [config.yml](config.yml)
     - `remove_unhealthy`: Remove unhealthy proxies from rotation
     - `fallback`: Recommended for continuous operation in case of proxy failures
     - `fallback_max_retries`: Number of retries for fallback. If this is reached, the response will be returned "bad gateway"
+    - `follow_redirect`: Follow HTTP redirection
     - `timeout`: Timeout for proxy requests
     - `retries`: Number of retries to get a healthy proxy
   - `rate_limit`: Rate limiting configurations

--- a/config.yml
+++ b/config.yml
@@ -2,6 +2,7 @@ proxy_file: "proxies.txt"
 file_watch: true # watch for file changes and reload proxies
 
 proxy:
+  host: "127.0.0.1" # proxy server host, leaving it empty will bind to all network interfaces
   port: 8080 # proxy server port
   authentication:
     enabled: false # enable basic authentication
@@ -14,6 +15,7 @@ proxy:
     remove_unhealthy: true # remove unhealthy proxies from rotation
     fallback: true # recommended for continuous operation in case of proxy failures
     fallback_max_retries: 10 # number of retries for fallback. if this is reached, the response will be returned "bad gateway"
+    follow_redirect: false # follow HTTP redirection
     timeout: 30 # seconds
     retries: 2 # number of retries to get a healthy proxy
   rate_limit:

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -10,6 +10,7 @@ type Config struct {
 }
 
 type ProxyConfig struct {
+	Host           string                    `yaml:"host"`
 	Port           int                       `yaml:"port"`
 	Authentication ProxyAuthenticationConfig `yaml:"authentication"`
 	Rotation       ProxyRotationConfig       `yaml:"rotation"`
@@ -30,6 +31,7 @@ type ProxyRotationConfig struct {
 	FallbackMaxRetries int             `yaml:"fallback_max_retries"`
 	Timeout            int             `yaml:"timeout"`
 	Retries            int             `yaml:"retries"`
+	FollowRedirect     bool            `yaml:"follow_redirect"`
 }
 
 type RateLimitConfig struct {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -40,9 +40,12 @@ func (ps *ProxyServer) Listen() {
 	ps.setUpHandlers()
 	time.Sleep(500 * time.Millisecond)
 
-	port := fmt.Sprintf(":%d", ps.cfg.Proxy.Port)
-	slog.Info(msgProxyServerStarted, "port", port)
-	err := http.ListenAndServe(port, ps.goProxy)
+	host := ps.cfg.Proxy.Host
+	port := ps.cfg.Proxy.Port
+	address := fmt.Sprintf("%s:%d", host, port)
+
+	slog.Info(msgProxyServerStarted, "address", address)
+	err := http.ListenAndServe(address, ps.goProxy)
 	if err != nil {
 		slog.Error(msgFailedToListen, "error", err)
 		return

--- a/internal/proxy/proxy_types.go
+++ b/internal/proxy/proxy_types.go
@@ -68,6 +68,7 @@ const (
 	msgAliveProxy                = "alive proxy"
 	msgFailedToWriteOutputFile   = "failed to write output file"
 	msgStoppedAfter10Redirects   = "stopped after 10 redirects"
+	msgSkippedFollowingRedirect   = "skipped following redirect"
 )
 
 var hopHeaders = []string{


### PR DESCRIPTION
Hi alpkeskin, Thanks for this great tool. 

I noticed an [issue](https://github.com/alpkeskin/rota/issues/13) with automatic redirect following, which is also problematic for me. so, I made it optional via the config file.

I didn't want the proxy server to always bind to all network interfaces, so I modified it to bind to a specific host defined in the config file.