### PR TITLE
fix: 20 bugs + perf + per-source cleanup + instant-HC on sync

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -4,7 +4,6 @@ go 1.25.3
 
 require (
 	github.com/MarceloPetrucio/go-scalar-api-reference v0.0.0-20240521013641-ce5d2efe0e06
-	github.com/elazarl/goproxy v1.7.2
 	github.com/gammazero/workerpool v1.1.3
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-chi/cors v1.2.2

--- a/core/go.mod
+++ b/core/go.mod
@@ -46,7 +46,7 @@ require (
 	// golang.org/x/crypto promoted to direct above
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/sync v0.17.0 // indirect
-	golang.org/x/sys v0.37.0 // indirect
+	golang.org/x/sys v0.43.0
 	golang.org/x/text v0.30.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
 )

--- a/core/go.sum
+++ b/core/go.sum
@@ -7,8 +7,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ebitengine/purego v0.8.1 h1:sdRKd6plj7KYW33EH5As6YKfe8m9zbN9JMrOjNVF/BE=
 github.com/ebitengine/purego v0.8.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
-github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/gammazero/deque v0.2.0 h1:SkieyNB4bg2/uZZLxvya0Pq6diUlwx7m2TeT7GAIWaA=
 github.com/gammazero/deque v0.2.0/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
 github.com/gammazero/workerpool v1.1.3 h1:WixN4xzukFoN0XSeXF6puqEqFTl2mECI9S6W44HWy9Q=

--- a/core/go.sum
+++ b/core/go.sum
@@ -104,8 +104,8 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
-golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.30.0 h1:yznKA/E9zq54KzlzBEAWn1NXSQ8DIp/NYMy88xJjl4k=
 golang.org/x/text v0.30.0/go.mod h1:yDdHFIX9t+tORqspjENWgzaCVXgk0yYnYuSZ8UzzBVM=
 golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=

--- a/core/internal/api/handlers/proxy_handler.go
+++ b/core/internal/api/handlers/proxy_handler.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/alpkeskin/rota/core/internal/models"
 	"github.com/alpkeskin/rota/core/internal/repository"
@@ -275,7 +276,13 @@ func (h *ProxyHandler) BulkDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	deleted, err := h.proxyRepo.BulkDelete(r.Context(), req.IDs)
+	// Use a detached context so client disconnect during a long delete doesn't
+	// cancel the DB operation mid-way. Large bulk deletes can take tens of
+	// seconds against TimescaleDB with CASCADE on proxy_requests.
+	dbCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	deleted, err := h.proxyRepo.BulkDelete(dbCtx, req.IDs)
 	if err != nil {
 		h.logger.Error("failed to bulk delete proxies", "error", err)
 		h.errorResponse(w, http.StatusInternalServerError, "Failed to delete proxies")
@@ -414,7 +421,13 @@ func (h *ProxyHandler) exportCSV(w http.ResponseWriter, proxies []models.ProxyWi
 
 // DeleteAll removes every proxy from the database.
 func (h *ProxyHandler) DeleteAll(w http.ResponseWriter, r *http.Request) {
-	deleted, err := h.proxyRepo.DeleteAll(r.Context())
+	// Use a detached context so client disconnect doesn't cancel the delete.
+	// Deleting all proxies can take minutes when there are many rows in
+	// proxy_requests (CASCADE delete on foreign key).
+	dbCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	deleted, err := h.proxyRepo.DeleteAll(dbCtx)
 	if err != nil {
 		h.logger.Error("failed to delete all proxies", "error", err)
 		h.errorResponse(w, http.StatusInternalServerError, "Failed to delete all proxies")

--- a/core/internal/api/handlers/settings_handler.go
+++ b/core/internal/api/handlers/settings_handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -12,16 +13,24 @@ import (
 
 // SettingsHandler handles settings endpoints
 type SettingsHandler struct {
-	settingsRepo *repository.SettingsRepository
-	logger       *logger.Logger
+	settingsRepo     *repository.SettingsRepository
+	logger           *logger.Logger
+	onSettingsUpdate func(ctx context.Context) // called after settings are persisted
 }
 
-// NewSettingsHandler creates a new SettingsHandler
-func NewSettingsHandler(settingsRepo *repository.SettingsRepository, log *logger.Logger) *SettingsHandler {
+// NewSettingsHandler creates a new SettingsHandler.
+// onUpdate is an optional callback invoked after settings are saved (e.g. to reload the proxy server).
+func NewSettingsHandler(settingsRepo *repository.SettingsRepository, log *logger.Logger, onUpdate func(ctx context.Context)) *SettingsHandler {
 	return &SettingsHandler{
-		settingsRepo: settingsRepo,
-		logger:       log,
+		settingsRepo:     settingsRepo,
+		logger:           log,
+		onSettingsUpdate: onUpdate,
 	}
+}
+
+// SetOnUpdate sets the callback invoked after settings are persisted.
+func (h *SettingsHandler) SetOnUpdate(fn func(ctx context.Context)) {
+	h.onSettingsUpdate = fn
 }
 
 // Get handles getting current configuration
@@ -96,6 +105,12 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.logger.Info("settings updated successfully")
+
+	// Reload proxy server so changes take effect immediately
+	if h.onSettingsUpdate != nil {
+		h.onSettingsUpdate(r.Context())
+	}
+
 	h.jsonResponse(w, http.StatusOK, response)
 }
 

--- a/core/internal/api/handlers/source_handler.go
+++ b/core/internal/api/handlers/source_handler.go
@@ -57,6 +57,16 @@ func (h *SourceHandler) Create(w http.ResponseWriter, r *http.Request) {
 	if req.IntervalMinutes <= 0 {
 		req.IntervalMinutes = 60
 	}
+	// cleanup_days bounds
+	if req.CleanupDays < 0 {
+		req.CleanupDays = 0
+	}
+	if req.CleanupDays > 365 {
+		req.CleanupDays = 365
+	}
+	if req.CleanupEnabled && req.CleanupDays == 0 {
+		req.CleanupDays = 7 // sensible default
+	}
 
 	src, err := h.sourceRepo.Create(r.Context(), req)
 	if err != nil {
@@ -78,6 +88,13 @@ func (h *SourceHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
 		return
+	}
+	// cleanup_days bounds
+	if req.CleanupDays < 0 {
+		req.CleanupDays = 0
+	}
+	if req.CleanupDays > 365 {
+		req.CleanupDays = 365
 	}
 	src, err := h.sourceRepo.Update(r.Context(), id, req)
 	if err != nil || src == nil {

--- a/core/internal/api/server.go
+++ b/core/internal/api/server.go
@@ -87,6 +87,7 @@ func New(cfg *config.Config, log *logger.Logger, db *database.DB) *Server {
 	// GeoIP + source + pool services
 	geoSvc := services.NewGeoIPService(log)
 	sourceSvc := services.NewSourceService(sourceRepo, proxyRepo, poolRepo, geoSvc, log)
+	sourceSvc.SetHealthChecker(healthChecker) // auto health-check after source import
 	poolSvc := services.NewPoolService(poolRepo, proxyRepo, log)
 
 	// Initialize handlers
@@ -153,6 +154,10 @@ func New(cfg *config.Config, log *logger.Logger, db *database.DB) *Server {
 	sourceSvc.Start(context.Background())
 	poolSvc.Start(context.Background())
 	alertWatcher.Start(context.Background())
+
+	// Periodic health check: re-tests ALL proxies (including failed) every 5 minutes.
+	// This recovers proxies that were temporarily down.
+	go healthChecker.StartPeriodicHealthCheck(context.Background(), 5*time.Minute)
 	cleanupSvc.Start(context.Background())
 
 	s.setupMiddleware()

--- a/core/internal/api/server.go
+++ b/core/internal/api/server.go
@@ -87,7 +87,11 @@ func New(cfg *config.Config, log *logger.Logger, db *database.DB) *Server {
 	// GeoIP + source + pool services
 	geoSvc := services.NewGeoIPService(log)
 	sourceSvc := services.NewSourceService(sourceRepo, proxyRepo, poolRepo, geoSvc, log)
-	sourceSvc.SetHealthChecker(healthChecker) // auto health-check after source import
+	// NOTE: Intentionally NOT wiring healthChecker into sourceSvc or starting a
+	// global periodic health check. The global HealthChecker uses a lenient
+	// 60s timeout and was flapping pool-marked 'failed' proxies back to 'active',
+	// putting dead proxies back into rotation. Pool-level health checks (cron-
+	// scheduled per pool in PoolService) are the single source of truth.
 	poolSvc := services.NewPoolService(poolRepo, proxyRepo, log)
 
 	// Initialize handlers
@@ -155,9 +159,11 @@ func New(cfg *config.Config, log *logger.Logger, db *database.DB) *Server {
 	poolSvc.Start(context.Background())
 	alertWatcher.Start(context.Background())
 
-	// Periodic health check: re-tests ALL proxies (including failed) every 5 minutes.
-	// This recovers proxies that were temporarily down.
-	go healthChecker.StartPeriodicHealthCheck(context.Background(), 5*time.Minute)
+	// NOTE: global StartPeriodicHealthCheck is intentionally NOT started.
+	// Its 60s timeout was too lenient and kept flapping pool-marked 'failed'
+	// proxies back to 'active', returning dead proxies to rotation.
+	// Pool-level health checks (PoolService cron) are authoritative.
+
 	cleanupSvc.Start(context.Background())
 
 	s.setupMiddleware()

--- a/core/internal/api/server.go
+++ b/core/internal/api/server.go
@@ -95,7 +95,7 @@ func New(cfg *config.Config, log *logger.Logger, db *database.DB) *Server {
 	dashboardHandler := handlers.NewDashboardHandler(dashboardRepo, proxyRepo, log)
 	proxyHandler := handlers.NewProxyHandler(proxyRepo, healthChecker, log)
 	logsHandler := handlers.NewLogsHandler(logRepo, log)
-	settingsHandler := handlers.NewSettingsHandler(settingsRepo, log)
+	settingsHandler := handlers.NewSettingsHandler(settingsRepo, log, nil) // onUpdate set below
 	websocketHandler := handlers.NewWebSocketHandler(dashboardRepo, proxyRepo, logRepo, log)
 	metricsHandler := handlers.NewMetricsHandler(log)
 	documentationHandler := handlers.NewDocumentationHandler()
@@ -133,6 +133,17 @@ func New(cfg *config.Config, log *logger.Logger, db *database.DB) *Server {
 		poolHandler:          poolHandler,
 		userHandler:          userHandler,
 	}
+
+	// Wire settings reload: when settings are updated via API, reload proxy server
+	settingsHandler.SetOnUpdate(func(ctx context.Context) {
+		if s.proxyServer != nil {
+			if err := s.proxyServer.ReloadSettings(ctx); err != nil {
+				log.Error("failed to reload proxy settings after update", "error", err)
+			} else {
+				log.Info("proxy settings reloaded after update")
+			}
+		}
+	})
 
 	// Alert watcher + proxy cleanup services
 	alertWatcher := services.NewAlertWatcher(poolRepo, log)

--- a/core/internal/database/migrations.go
+++ b/core/internal/database/migrations.go
@@ -482,6 +482,32 @@ var migrations = []Migration{
 			WHERE key = 'healthcheck';
 		`,
 	},
+	{
+		Version:     21,
+		Description: "Source: last_total column + per-source soft cleanup settings + proxies.last_seen_at",
+		Up: `
+			-- proxy_sources: total lines in last fetch + opt-in cleanup config
+			ALTER TABLE proxy_sources
+			  ADD COLUMN IF NOT EXISTS last_total       INTEGER NOT NULL DEFAULT 0,
+			  ADD COLUMN IF NOT EXISTS cleanup_enabled  BOOLEAN NOT NULL DEFAULT false,
+			  ADD COLUMN IF NOT EXISTS cleanup_days     INTEGER NOT NULL DEFAULT 7;
+
+			-- proxies: last time a proxy was seen in its source's fetch response
+			ALTER TABLE proxies
+			  ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMP;
+
+			CREATE INDEX IF NOT EXISTS idx_proxies_source_last_seen
+			  ON proxies(source_id, last_seen_at)
+			  WHERE source_id IS NOT NULL;
+		`,
+		Down: `
+			DROP INDEX IF EXISTS idx_proxies_source_last_seen;
+			ALTER TABLE proxies       DROP COLUMN IF EXISTS last_seen_at;
+			ALTER TABLE proxy_sources DROP COLUMN IF EXISTS cleanup_days;
+			ALTER TABLE proxy_sources DROP COLUMN IF EXISTS cleanup_enabled;
+			ALTER TABLE proxy_sources DROP COLUMN IF EXISTS last_total;
+		`,
+	},
 }
 
 // Migrate runs all pending migrations

--- a/core/internal/models/pool.go
+++ b/core/internal/models/pool.go
@@ -69,6 +69,8 @@ type PoolProxy struct {
 	ProxyID         int        `json:"proxy_id"`
 	Address         string     `json:"address"`
 	Protocol        string     `json:"protocol"`
+	Username        *string    `json:"-"`
+	Password        *string    `json:"-"`
 	Status          string     `json:"status"`
 	CountryCode     *string    `json:"country_code,omitempty"`
 	CountryName     *string    `json:"country_name,omitempty"`
@@ -80,6 +82,17 @@ type PoolProxy struct {
 	AvgResponseTime int        `json:"avg_response_time"`
 	LastCheck       *time.Time `json:"last_check,omitempty"`
 	AddedAt         time.Time  `json:"added_at"`
+}
+
+// ToProxy converts a PoolProxy to a Proxy (for transport creation with auth).
+func (pp *PoolProxy) ToProxy() *Proxy {
+	return &Proxy{
+		ID:       pp.ProxyID,
+		Address:  pp.Address,
+		Protocol: pp.Protocol,
+		Username: pp.Username,
+		Password: pp.Password,
+	}
 }
 
 // PoolHealthCheckResult is per-proxy result from a pool health check run

--- a/core/internal/models/source.go
+++ b/core/internal/models/source.go
@@ -11,8 +11,11 @@ type ProxySource struct {
 	Enabled         bool       `json:"enabled"`
 	IntervalMinutes int        `json:"interval_minutes"`
 	LastFetchedAt   *time.Time `json:"last_fetched_at,omitempty"`
-	LastCount       int        `json:"last_count"`
+	LastCount       int        `json:"last_count"`        // newly imported on last fetch
+	LastTotal       int        `json:"last_total"`        // total lines returned on last fetch
 	LastError       *string    `json:"last_error,omitempty"`
+	CleanupEnabled  bool       `json:"cleanup_enabled"`   // per-source opt-in soft cleanup
+	CleanupDays     int        `json:"cleanup_days"`      // delete proxies stale for this many days
 	CreatedAt       time.Time  `json:"created_at"`
 	UpdatedAt       time.Time  `json:"updated_at"`
 }
@@ -24,6 +27,8 @@ type CreateProxySourceRequest struct {
 	Protocol        string `json:"protocol" validate:"required,oneof=http https socks4 socks4a socks5"`
 	Enabled         bool   `json:"enabled"`
 	IntervalMinutes int    `json:"interval_minutes" validate:"min=1"`
+	CleanupEnabled  bool   `json:"cleanup_enabled"`
+	CleanupDays     int    `json:"cleanup_days" validate:"omitempty,min=1,max=365"`
 }
 
 // UpdateProxySourceRequest is the payload for updating a source
@@ -33,4 +38,6 @@ type UpdateProxySourceRequest struct {
 	Protocol        string `json:"protocol" validate:"omitempty,oneof=http https socks4 socks4a socks5"`
 	Enabled         *bool  `json:"enabled"`
 	IntervalMinutes int    `json:"interval_minutes" validate:"omitempty,min=1"`
+	CleanupEnabled  *bool  `json:"cleanup_enabled"`
+	CleanupDays     int    `json:"cleanup_days" validate:"omitempty,min=1,max=365"`
 }

--- a/core/internal/proxy/connect_test.go
+++ b/core/internal/proxy/connect_test.go
@@ -1,0 +1,247 @@
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alpkeskin/rota/core/internal/models"
+)
+
+// TestConnectViaHTTPStandalone tests the HTTP CONNECT handshake against a mock proxy.
+func TestConnectViaHTTPStandalone_Success(t *testing.T) {
+	// Start a mock HTTP CONNECT proxy.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		reader := bufio.NewReader(conn)
+		line, _ := reader.ReadString('\n')
+		if !strings.HasPrefix(line, "CONNECT") {
+			conn.Write([]byte("HTTP/1.1 400 Bad Request\r\n\r\n"))
+			return
+		}
+		for {
+			hdr, _ := reader.ReadString('\n')
+			if strings.TrimSpace(hdr) == "" {
+				break
+			}
+		}
+		// Send 200 OK response.
+		conn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+
+		// After tunnel is established, echo back what client sends.
+		io.Copy(conn, conn)
+	}()
+
+	proxy := &models.Proxy{
+		Address:  ln.Addr().String(),
+		Protocol: "http",
+	}
+
+	conn, err := connectViaHTTPStandalone(proxy, "example.com:443", 10*time.Second)
+	if err != nil {
+		t.Fatalf("connectViaHTTPStandalone: %v", err)
+	}
+	defer conn.Close()
+
+	// Tunnel is established — test bidirectional communication.
+	msg := "hello tunnel"
+	conn.Write([]byte(msg))
+
+	buf := make([]byte, 256)
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf[:n]) != msg {
+		t.Fatalf("got %q, want %q", buf[:n], msg)
+	}
+}
+
+func TestConnectViaHTTPStandalone_Rejected(t *testing.T) {
+	// Mock proxy that rejects CONNECT.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		reader := bufio.NewReader(conn)
+		reader.ReadString('\n') // consume CONNECT line
+		for {
+			hdr, _ := reader.ReadString('\n')
+			if strings.TrimSpace(hdr) == "" {
+				break
+			}
+		}
+		conn.Write([]byte("HTTP/1.1 403 Forbidden\r\n\r\n"))
+	}()
+
+	proxy := &models.Proxy{
+		Address:  ln.Addr().String(),
+		Protocol: "http",
+	}
+
+	_, err = connectViaHTTPStandalone(proxy, "example.com:443", 10*time.Second)
+	if err == nil {
+		t.Fatal("expected error for rejected CONNECT")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Fatalf("expected 403 in error, got: %v", err)
+	}
+}
+
+func TestConnectViaHTTPStandalone_WithAuth(t *testing.T) {
+	// Mock proxy that checks Proxy-Authorization.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		reader := bufio.NewReader(conn)
+		reader.ReadString('\n') // CONNECT line
+
+		hasAuth := false
+		for {
+			hdr, _ := reader.ReadString('\n')
+			if strings.HasPrefix(hdr, "Proxy-Authorization:") {
+				hasAuth = true
+			}
+			if strings.TrimSpace(hdr) == "" {
+				break
+			}
+		}
+
+		if hasAuth {
+			conn.Write([]byte("HTTP/1.1 200 OK\r\n\r\n"))
+		} else {
+			conn.Write([]byte("HTTP/1.1 407 Proxy Authentication Required\r\n\r\n"))
+		}
+	}()
+
+	user := "testuser"
+	pass := "testpass"
+	proxy := &models.Proxy{
+		Address:  ln.Addr().String(),
+		Protocol: "http",
+		Username: &user,
+		Password: &pass,
+	}
+
+	conn, err := connectViaHTTPStandalone(proxy, "example.com:443", 10*time.Second)
+	if err != nil {
+		t.Fatalf("expected success with auth, got: %v", err)
+	}
+	conn.Close()
+}
+
+func TestConnectViaHTTPStandalone_ConnectionRefused(t *testing.T) {
+	proxy := &models.Proxy{
+		Address:  "127.0.0.1:1", // nothing listening
+		Protocol: "http",
+	}
+
+	_, err := connectViaHTTPStandalone(proxy, "example.com:443", 2*time.Second)
+	if err == nil {
+		t.Fatal("expected error for connection refused")
+	}
+}
+
+// TestConnectViaSocks5 tests SOCKS5 connection against a mock server.
+// Note: This is a basic test — a real SOCKS5 handshake mock is non-trivial.
+func TestConnectViaSocks5_ConnectionRefused(t *testing.T) {
+	proxy := &models.Proxy{
+		Address:  "127.0.0.1:1", // nothing listening
+		Protocol: "socks5",
+	}
+
+	_, err := connectViaSocks5(proxy, "example.com:443")
+	if err == nil {
+		t.Fatal("expected error for unreachable SOCKS5 proxy")
+	}
+}
+
+// TestConnectViaProxyStandalone_UnsupportedProtocol tests the protocol switch.
+func TestConnectViaProxyStandalone_UnsupportedProtocol(t *testing.T) {
+	proxy := &models.Proxy{
+		Address:  "127.0.0.1:9999",
+		Protocol: "ftp",
+	}
+	settings := &models.RotationSettings{Timeout: 5}
+
+	_, err := connectViaProxyStandalone(proxy, "example.com:443", settings)
+	if err == nil {
+		t.Fatal("expected error for unsupported protocol")
+	}
+	if !strings.Contains(err.Error(), "unsupported") {
+		t.Fatalf("expected 'unsupported' in error, got: %v", err)
+	}
+}
+
+// TestConnectViaProxyStandalone_RoutesHTTP verifies HTTP protocol goes to HTTP handler.
+func TestConnectViaProxyStandalone_RoutesHTTP(t *testing.T) {
+	// Start mock that accepts CONNECT.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		reader := bufio.NewReader(conn)
+		for {
+			line, _ := reader.ReadString('\n')
+			if strings.TrimSpace(line) == "" {
+				break
+			}
+		}
+		fmt.Fprint(conn, "HTTP/1.1 200 OK\r\n\r\n")
+	}()
+
+	proxy := &models.Proxy{
+		Address:  ln.Addr().String(),
+		Protocol: "http",
+	}
+	settings := &models.RotationSettings{Timeout: 10}
+
+	conn, err := connectViaProxyStandalone(proxy, "example.com:443", settings)
+	if err != nil {
+		t.Fatalf("expected success: %v", err)
+	}
+	conn.Close()
+}

--- a/core/internal/proxy/handler.go
+++ b/core/internal/proxy/handler.go
@@ -298,11 +298,11 @@ func (h *UpstreamProxyHandler) sendWithRetry(req *http.Request, ctx context.Cont
 					ErrorMessage: err.Error(),
 					Timestamp:    time.Now(),
 				}
+				// RecordRequest → updateProxyStats handles the 3-consecutive-failures
+				// threshold naturally. Do NOT call UpdateProxyStatus("failed") here —
+				// that bypasses the threshold and kills the proxy on first failure.
 				if recordErr := h.tracker.RecordRequest(recordCtx, record); recordErr != nil {
 					h.logger.Error("failed to record failed request", "error", recordErr)
-				}
-				if markErr := h.tracker.UpdateProxyStatus(recordCtx, selectedProxy.ID, "failed"); markErr != nil {
-					h.logger.Error("failed to mark proxy as failed", "error", markErr)
 				}
 			}()
 

--- a/core/internal/proxy/handler.go
+++ b/core/internal/proxy/handler.go
@@ -1,9 +1,11 @@
 package proxy
 
 import (
+	"bufio"
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -11,7 +13,6 @@ import (
 
 	"github.com/alpkeskin/rota/core/internal/models"
 	"github.com/alpkeskin/rota/core/pkg/logger"
-	"github.com/elazarl/goproxy"
 	"github.com/google/uuid"
 	proxyDialer "golang.org/x/net/proxy"
 )
@@ -41,67 +42,65 @@ func NewUpstreamProxyHandler(
 	}
 }
 
-// HandleRequest handles HTTP requests with upstream proxy rotation
-func (h *UpstreamProxyHandler) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+// HandleHTTPRequest handles HTTP requests (non-CONNECT) with upstream proxy rotation.
+// It writes the proxied response directly to w.
+func (h *UpstreamProxyHandler) HandleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
 	requestID := uuid.New().String()
 
-	h.logger.Info("handling proxy request",
+	h.logger.Debug("handling proxy request",
 		"source", "proxy",
 		"request_id", requestID,
-		"method", req.Method,
-		"url", req.URL.String(),
+		"method", r.Method,
+		"url", r.URL.String(),
 	)
 
 	// Remove hop-by-hop headers
-	h.removeHopByHopHeaders(req)
+	h.removeHopByHopHeaders(r)
 
 	// --- Pool-aware path: if a PoolChain was attached by UserAuthMiddleware, use it ---
-	reqCtx := req.Context()
+	reqCtx := r.Context()
 	if chain, ok := reqCtx.Value(UserChainContextKey).(*PoolChain); ok && chain != nil {
-		resp, proxyID, err := chain.SendWithRetry(req, reqCtx, h.settings, h.logger)
+		resp, proxyID, err := chain.SendWithRetry(r, reqCtx, h.settings, h.logger)
 		duration := int(time.Since(startTime).Milliseconds())
 		if proxyID > 0 {
-			h.recordAsync(proxyID, "", req.URL.String(), req.Method, resp, err, duration, startTime)
+			h.recordAsync(proxyID, "", r.URL.String(), r.Method, resp, err, duration, startTime)
 		}
 		if err != nil {
 			h.logger.Error("pool-chain request failed", "request_id", requestID, "error", err)
-			return req, h.badGateway(err.Error())
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
 		}
-		return req, resp
+		copyResponse(w, resp)
+		return
 	}
 
 	// --- Legacy path: global proxy pool ---
-	// Try to send request through proxy pool with retry/fallback
-	resp, proxyID, err := h.sendWithRetry(req, ctx.Req.Context())
+	resp, proxyID, err := h.sendWithRetry(r, r.Context())
 	duration := int(time.Since(startTime).Milliseconds())
 
 	// Record the request
 	if proxyID > 0 {
 		record := RequestRecord{
 			ProxyID:      proxyID,
-			ProxyAddress: "", // Will be filled from proxy info
-			RequestedURL: req.URL.String(),
-			Method:       req.Method,
+			ProxyAddress: "",
+			RequestedURL: r.URL.String(),
+			Method:       r.Method,
 			Success:      err == nil && resp != nil,
 			ResponseTime: duration,
 			Timestamp:    startTime,
 		}
-
 		if resp != nil {
 			record.StatusCode = resp.StatusCode
 		}
-
 		if err != nil {
 			record.ErrorMessage = err.Error()
 		}
-
-		// Record asynchronously to not block the request
 		go func() {
 			recordCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			if err := h.tracker.RecordRequest(recordCtx, record); err != nil {
-				h.logger.Error("failed to record request", "error", err)
+			if recordErr := h.tracker.RecordRequest(recordCtx, record); recordErr != nil {
+				h.logger.Error("failed to record request", "error", recordErr)
 			}
 		}()
 	}
@@ -110,25 +109,132 @@ func (h *UpstreamProxyHandler) HandleRequest(req *http.Request, ctx *goproxy.Pro
 		h.logger.Error("proxy request failed",
 			"source", "proxy",
 			"request_id", requestID,
-			"method", req.Method,
-			"url", req.URL.String(),
 			"error", err,
 			"duration_ms", duration,
 		)
-		return req, h.badGateway(err.Error())
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
 	}
 
-	h.logger.Info("proxy request completed",
+	h.logger.Debug("proxy request completed",
 		"source", "proxy",
 		"request_id", requestID,
-		"method", req.Method,
-		"url", req.URL.String(),
 		"status", resp.StatusCode,
 		"duration_ms", duration,
-		"proxy_id", proxyID,
 	)
 
-	return req, resp
+	copyResponse(w, resp)
+}
+
+// HandleConnectRequest handles HTTPS CONNECT requests.
+// It hijacks the client connection, establishes an upstream tunnel,
+// and copies data bidirectionally using splice(2) on Linux.
+func (h *UpstreamProxyHandler) HandleConnectRequest(w http.ResponseWriter, r *http.Request) {
+	startTime := time.Now()
+	host := r.Host
+
+	h.logger.Debug("handling CONNECT request",
+		"source", "proxy",
+		"host", host,
+	)
+
+	// Establish upstream connection (pool-chain or global)
+	var upstreamConn net.Conn
+	var proxyID int
+	var err error
+
+	reqCtx := r.Context()
+	if chain, ok := reqCtx.Value(UserChainContextKey).(*PoolChain); ok && chain != nil {
+		upstreamConn, proxyID, err = chain.ConnectWithRetry(host, reqCtx, h.settings, h.logger)
+	} else {
+		upstreamConn, proxyID, err = h.connectThroughProxy(host, reqCtx)
+	}
+
+	if err != nil {
+		h.logger.Error("CONNECT upstream failed",
+			"source", "proxy",
+			"host", host,
+			"error", err,
+		)
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer upstreamConn.Close()
+
+	// Hijack the client connection from the HTTP server.
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		h.logger.Error("ResponseWriter does not support Hijack")
+		http.Error(w, "hijack not supported", http.StatusInternalServerError)
+		return
+	}
+
+	clientConn, clientBuf, err := hijacker.Hijack()
+	if err != nil {
+		h.logger.Error("hijack failed", "error", err)
+		return
+	}
+	defer clientConn.Close()
+
+	// Send 200 Connection Established to the client.
+	if _, err := clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
+		h.logger.Error("failed to write CONNECT response", "error", err)
+		return
+	}
+
+	// Drain any buffered data the HTTP server read ahead.
+	if clientBuf != nil && clientBuf.Reader.Buffered() > 0 {
+		buffered := make([]byte, clientBuf.Reader.Buffered())
+		if _, err := io.ReadFull(clientBuf.Reader, buffered); err == nil {
+			upstreamConn.Write(buffered) //nolint:errcheck
+		}
+	}
+
+	// Record the successful CONNECT.
+	duration := int(time.Since(startTime).Milliseconds())
+	if proxyID > 0 {
+		go func() {
+			recordCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			record := RequestRecord{
+				ProxyID:      proxyID,
+				ProxyAddress: "",
+				RequestedURL: "CONNECT://" + host,
+				Method:       "CONNECT",
+				Success:      true,
+				ResponseTime: duration,
+				StatusCode:   200,
+				Timestamp:    startTime,
+			}
+			h.tracker.RecordRequest(recordCtx, record) //nolint:errcheck
+		}()
+	}
+
+	// Bidirectional copy — uses splice(2) on Linux for zero-copy.
+	BidirectionalCopy(clientConn, upstreamConn)
+}
+
+// copyResponse writes an *http.Response to an http.ResponseWriter.
+func copyResponse(w http.ResponseWriter, resp *http.Response) {
+	if resp == nil {
+		http.Error(w, "empty upstream response", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Copy headers
+	for k, vv := range resp.Header {
+		for _, v := range vv {
+			w.Header().Add(k, v)
+		}
+	}
+
+	w.WriteHeader(resp.StatusCode)
+
+	// Use pooled buffer for the body copy
+	buf := bufPool.Get().([]byte)
+	defer bufPool.Put(buf)
+	io.CopyBuffer(w, resp.Body, buf) //nolint:errcheck
 }
 
 // sendWithRetry attempts to send the request with retry and fallback logic
@@ -138,60 +244,47 @@ func (h *UpstreamProxyHandler) sendWithRetry(req *http.Request, ctx context.Cont
 		maxFallbackRetries = 1
 	}
 
-	// Use Retries setting for per-proxy retries
 	perProxyRetries := h.settings.Retries
 	if perProxyRetries <= 0 {
-		perProxyRetries = 1 // Default to 1 if not set
+		perProxyRetries = 1
 	}
 
-	h.logger.Info("starting proxy selection",
+	h.logger.Debug("starting proxy selection",
 		"source", "proxy",
 		"max_fallback_retries", maxFallbackRetries,
 		"per_proxy_retries", perProxyRetries,
-		"url", req.URL.String(),
 	)
 
 	var lastErr error
 	triedProxies := make(map[int]bool)
 
 	for fallbackAttempt := 0; fallbackAttempt < maxFallbackRetries; fallbackAttempt++ {
-		// Select a proxy
 		selectedProxy, err := h.selector.Select(ctx)
 		if err != nil {
-			h.logger.Error("no proxy available - request will fail",
-				"source", "proxy",
-				"error", err,
-			)
-			return nil, 0, fmt.Errorf("no proxy available - please add proxies to the system: %w", err)
+			return nil, 0, fmt.Errorf("no proxy available: %w", err)
 		}
 
-		// Skip if we've already tried this proxy
 		if triedProxies[selectedProxy.ID] {
 			continue
 		}
 		triedProxies[selectedProxy.ID] = true
 
-		h.logger.Info("attempting request with proxy",
+		h.logger.Debug("attempting request with proxy",
 			"source", "proxy",
 			"proxy_id", selectedProxy.ID,
 			"proxy_address", selectedProxy.Address,
 			"fallback_attempt", fallbackAttempt+1,
 		)
 
-		// Try this proxy with retries
 		resp, err := h.tryProxyWithRetries(req, ctx, selectedProxy, perProxyRetries)
 		if err != nil {
 			lastErr = fmt.Errorf("proxy %s failed after %d retries: %w", selectedProxy.Address, perProxyRetries, err)
 			h.logger.Warn("proxy failed after all retries",
 				"source", "proxy",
 				"proxy_id", selectedProxy.ID,
-				"proxy_address", selectedProxy.Address,
-				"fallback_attempt", fallbackAttempt+1,
-				"retries_attempted", perProxyRetries,
 				"error", err,
 			)
 
-			// Record the failed request to mark proxy as failed if needed
 			go func() {
 				recordCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
@@ -208,8 +301,6 @@ func (h *UpstreamProxyHandler) sendWithRetry(req *http.Request, ctx context.Cont
 				if recordErr := h.tracker.RecordRequest(recordCtx, record); recordErr != nil {
 					h.logger.Error("failed to record failed request", "error", recordErr)
 				}
-
-				// Immediately mark proxy as failed to prevent further selection
 				if markErr := h.tracker.UpdateProxyStatus(recordCtx, selectedProxy.ID, "failed"); markErr != nil {
 					h.logger.Error("failed to mark proxy as failed", "error", markErr)
 				}
@@ -218,14 +309,6 @@ func (h *UpstreamProxyHandler) sendWithRetry(req *http.Request, ctx context.Cont
 			continue
 		}
 
-		h.logger.Info("proxy succeeded",
-			"source", "proxy",
-			"proxy_id", selectedProxy.ID,
-			"proxy_address", selectedProxy.Address,
-			"fallback_attempt", fallbackAttempt+1,
-		)
-
-		// Success!
 		return resp, selectedProxy.ID, nil
 	}
 
@@ -237,29 +320,12 @@ func (h *UpstreamProxyHandler) tryProxyWithRetries(req *http.Request, ctx contex
 	var lastErr error
 
 	for retry := 0; retry < maxRetries; retry++ {
-		h.logger.Info("attempting request",
-			"source", "proxy",
-			"proxy_id", selectedProxy.ID,
-			"proxy_address", selectedProxy.Address,
-			"retry", retry+1,
-			"max_retries", maxRetries,
-		)
-
-		// Create transport for this proxy
-		transport, err := h.createTransport(selectedProxy)
+		transport, err := GetOrCreateTransport(selectedProxy)
 		if err != nil {
 			lastErr = fmt.Errorf("failed to create transport: %w", err)
-			h.logger.Warn("transport creation failed",
-				"source", "proxy",
-				"proxy_id", selectedProxy.ID,
-				"proxy_address", selectedProxy.Address,
-				"retry", retry+1,
-				"error", err,
-			)
 			continue
 		}
 
-		// Create HTTP client with timeout
 		client := &http.Client{
 			Transport: transport,
 			Timeout:   time.Duration(h.settings.Timeout) * time.Second,
@@ -274,39 +340,16 @@ func (h *UpstreamProxyHandler) tryProxyWithRetries(req *http.Request, ctx contex
 			},
 		}
 
-		// Clone the request for retry
 		clonedReq := req.Clone(ctx)
-
-		// CRITICAL FIX: Clear RequestURI for client requests
-		// RequestURI is only for server-side, not for outgoing client requests
 		clonedReq.RequestURI = ""
 
-		// Send the request
 		resp, err := client.Do(clonedReq)
 		if err != nil {
 			lastErr = fmt.Errorf("proxy %s failed: %w", selectedProxy.Address, err)
-			h.logger.Warn("proxy request failed",
-				"source", "proxy",
-				"proxy_id", selectedProxy.ID,
-				"proxy_address", selectedProxy.Address,
-				"retry", retry+1,
-				"max_retries", maxRetries,
-				"error", err,
-			)
-
-			// If this is not the last retry, continue to next retry
 			if retry < maxRetries-1 {
 				continue
 			}
 		} else {
-			// Success!
-			h.logger.Info("proxy request succeeded",
-				"source", "proxy",
-				"proxy_id", selectedProxy.ID,
-				"proxy_address", selectedProxy.Address,
-				"retry", retry+1,
-				"status_code", resp.StatusCode,
-			)
 			return resp, nil
 		}
 	}
@@ -314,49 +357,193 @@ func (h *UpstreamProxyHandler) tryProxyWithRetries(req *http.Request, ctx contex
 	return nil, lastErr
 }
 
-// createTransport creates an HTTP transport for the given proxy
-func (h *UpstreamProxyHandler) createTransport(p *models.Proxy) (*http.Transport, error) {
-	h.logger.Info("creating transport for proxy",
-		"source", "proxy",
-		"proxy_id", p.ID,
-		"proxy_address", p.Address,
-		"protocol", p.Protocol,
-		"has_auth", p.Username != nil && *p.Username != "",
-	)
+// connectThroughProxy establishes a connection through upstream proxy with retry logic
+func (h *UpstreamProxyHandler) connectThroughProxy(host string, ctx context.Context) (net.Conn, int, error) {
+	startTime := time.Now()
 
-	transport, err := CreateProxyTransport(p)
-	if err != nil {
-		return nil, err
+	maxFallbackRetries := h.settings.FallbackMaxRetries
+	if !h.settings.Fallback {
+		maxFallbackRetries = 1
 	}
 
-	// Debug: Verify proxy is set
-	if transport.Proxy != nil {
-		// Get a sample URL to test proxy function
-		testReq, _ := http.NewRequest("GET", "https://example.com", nil)
-		proxyURL, proxyErr := transport.Proxy(testReq)
-		if proxyErr != nil {
-			h.logger.Warn("proxy function returned error",
-				"source", "proxy",
-				"error", proxyErr,
-			)
-		} else if proxyURL != nil {
-			h.logger.Info("transport proxy configured",
-				"source", "proxy",
-				"proxy_url", proxyURL.String(),
-			)
-		} else {
-			h.logger.Warn("transport proxy function returned nil",
-				"source", "proxy",
-			)
+	perProxyRetries := h.settings.Retries
+	if perProxyRetries <= 0 {
+		perProxyRetries = 1
+	}
+
+	var lastErr error
+	triedProxies := make(map[int]bool)
+
+	for fallbackAttempt := 0; fallbackAttempt < maxFallbackRetries; fallbackAttempt++ {
+		selectedProxy, err := h.selector.Select(ctx)
+		if err != nil {
+			return nil, 0, fmt.Errorf("no proxy available: %w", err)
 		}
-	} else {
-		h.logger.Error("transport proxy is nil - requests will go direct!",
-			"source", "proxy",
-			"proxy_id", p.ID,
-		)
+
+		if triedProxies[selectedProxy.ID] {
+			continue
+		}
+		triedProxies[selectedProxy.ID] = true
+
+		conn, err := h.tryConnectWithRetries(selectedProxy, host, perProxyRetries)
+		duration := int(time.Since(startTime).Milliseconds())
+
+		if err != nil {
+			lastErr = fmt.Errorf("proxy %s failed after %d retries: %w", selectedProxy.Address, perProxyRetries, err)
+
+			go func(proxyID int, proxyAddr string, failedDuration int, failErr error) {
+				recordCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				record := RequestRecord{
+					ProxyID:      proxyID,
+					ProxyAddress: proxyAddr,
+					RequestedURL: "CONNECT://" + host,
+					Method:       "CONNECT",
+					Success:      false,
+					ResponseTime: failedDuration,
+					ErrorMessage: failErr.Error(),
+					Timestamp:    startTime,
+				}
+				h.tracker.RecordRequest(recordCtx, record) //nolint:errcheck
+			}(selectedProxy.ID, selectedProxy.Address, duration, err)
+
+			continue
+		}
+
+		return conn, selectedProxy.ID, nil
 	}
 
-	return transport, nil
+	return nil, 0, fmt.Errorf("all proxies failed for CONNECT, last error: %w", lastErr)
+}
+
+// tryConnectWithRetries attempts to connect through a specific proxy with retries
+func (h *UpstreamProxyHandler) tryConnectWithRetries(selectedProxy *models.Proxy, host string, maxRetries int) (net.Conn, error) {
+	var lastErr error
+
+	for retry := 0; retry < maxRetries; retry++ {
+		conn, err := h.connectViaProxy(selectedProxy, host)
+		if err != nil {
+			lastErr = fmt.Errorf("proxy %s failed: %w", selectedProxy.Address, err)
+			if retry < maxRetries-1 {
+				continue
+			}
+		} else {
+			return conn, nil
+		}
+	}
+
+	return nil, lastErr
+}
+
+// connectViaProxy establishes a connection through a specific proxy
+func (h *UpstreamProxyHandler) connectViaProxy(proxy *models.Proxy, host string) (net.Conn, error) {
+	switch proxy.Protocol {
+	case "socks5":
+		var dialer proxyDialer.Dialer
+		var err error
+
+		if proxy.Username != nil && *proxy.Username != "" {
+			password := ""
+			if proxy.Password != nil {
+				password = *proxy.Password
+			}
+			auth := &proxyDialer.Auth{
+				User:     *proxy.Username,
+				Password: password,
+			}
+			dialer, err = proxyDialer.SOCKS5("tcp", proxy.Address, auth, proxyDialer.Direct)
+		} else {
+			dialer, err = proxyDialer.SOCKS5("tcp", proxy.Address, nil, proxyDialer.Direct)
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to create SOCKS5 dialer: %w", err)
+		}
+
+		conn, err := dialer.Dial("tcp", host)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to %s via SOCKS5 proxy %s: %w", host, proxy.Address, err)
+		}
+
+		return conn, nil
+
+	case "http", "https":
+		return h.connectViaHTTPProxy(proxy, host)
+
+	default:
+		return nil, fmt.Errorf("unsupported proxy protocol for CONNECT: %s", proxy.Protocol)
+	}
+}
+
+// connectViaHTTPProxy establishes a connection through HTTP proxy using CONNECT method
+func (h *UpstreamProxyHandler) connectViaHTTPProxy(proxy *models.Proxy, host string) (net.Conn, error) {
+	timeout := time.Duration(h.settings.Timeout) * time.Second
+	if timeout < 60*time.Second {
+		timeout = 60 * time.Second
+	}
+
+	conn, err := net.DialTimeout("tcp", proxy.Address, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to proxy %s: %w", proxy.Address, err)
+	}
+
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to set connection deadline: %w", err)
+	}
+
+	connectReq := fmt.Sprintf("CONNECT %s HTTP/1.1\r\n", host)
+	connectReq += fmt.Sprintf("Host: %s\r\n", host)
+
+	if proxy.Username != nil && *proxy.Username != "" {
+		password := ""
+		if proxy.Password != nil {
+			password = *proxy.Password
+		}
+		auth := *proxy.Username + ":" + password
+		encoded := base64.StdEncoding.EncodeToString([]byte(auth))
+		connectReq += fmt.Sprintf("Proxy-Authorization: Basic %s\r\n", encoded)
+	}
+
+	connectReq += "User-Agent: Rota-Proxy/1.0\r\n"
+	connectReq += "Proxy-Connection: Keep-Alive\r\n"
+	connectReq += "\r\n"
+
+	if _, err = conn.Write([]byte(connectReq)); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to send CONNECT request: %w", err)
+	}
+
+	// Read the response.
+	reader := bufio.NewReader(conn)
+	statusLine, err := reader.ReadString('\n')
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to read CONNECT response: %w", err)
+	}
+
+	// Parse status: "HTTP/1.x 200 ..."
+	parts := strings.SplitN(strings.TrimSpace(statusLine), " ", 3)
+	if len(parts) < 2 || parts[1] != "200" {
+		conn.Close()
+		return nil, fmt.Errorf("CONNECT request failed: %s", strings.TrimSpace(statusLine))
+	}
+
+	// Consume remaining headers until empty line.
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil || strings.TrimSpace(line) == "" {
+			break
+		}
+	}
+
+	// Clear deadline for the tunnel phase.
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to clear connection deadline: %w", err)
+	}
+
+	return conn, nil
 }
 
 // removeHopByHopHeaders removes hop-by-hop headers that shouldn't be proxied
@@ -376,367 +563,11 @@ func (h *UpstreamProxyHandler) removeHopByHopHeaders(req *http.Request) {
 		req.Header.Del(header)
 	}
 
-	// Also remove headers specified in Connection header
 	if connections := req.Header.Get("Connection"); connections != "" {
 		for _, connection := range strings.Split(connections, ",") {
 			req.Header.Del(strings.TrimSpace(connection))
 		}
 	}
-}
-
-// ConnectThroughProxyForDial is called by goproxy's ConnectDial
-// It establishes a connection through the upstream proxy pool
-func (h *UpstreamProxyHandler) ConnectThroughProxyForDial(host string) (net.Conn, int, error) {
-	return h.connectThroughProxy(host, context.Background())
-}
-
-// HandleConnect handles HTTPS CONNECT requests through upstream proxy
-// NOTE: This is now only used for middleware (auth, rate limiting)
-// Actual connection is made by ConnectDial
-func (h *UpstreamProxyHandler) HandleConnect(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
-	requestID := uuid.New().String()
-
-	h.logger.Info("handling CONNECT request",
-		"source", "proxy",
-		"request_id", requestID,
-		"host", host,
-	)
-
-	// Note: We don't actually connect here anymore
-	// goproxy.ConnectDial will handle the actual connection
-	// This function is now only for middleware checks
-
-	return goproxy.OkConnect, host
-}
-
-// connectThroughProxy establishes a connection through upstream proxy with retry logic
-func (h *UpstreamProxyHandler) connectThroughProxy(host string, ctx context.Context) (net.Conn, int, error) {
-	startTime := time.Now()
-
-	maxFallbackRetries := h.settings.FallbackMaxRetries
-	if !h.settings.Fallback {
-		maxFallbackRetries = 1
-	}
-
-	// Use Retries setting for per-proxy retries
-	perProxyRetries := h.settings.Retries
-	if perProxyRetries <= 0 {
-		perProxyRetries = 1 // Default to 1 if not set
-	}
-
-	var lastErr error
-	triedProxies := make(map[int]bool)
-
-	for fallbackAttempt := 0; fallbackAttempt < maxFallbackRetries; fallbackAttempt++ {
-		// Select a proxy
-		selectedProxy, err := h.selector.Select(ctx)
-		if err != nil {
-			h.logger.Error("no proxy available for CONNECT - request will fail",
-				"source", "proxy",
-				"error", err,
-			)
-			return nil, 0, fmt.Errorf("no proxy available - please add proxies to the system: %w", err)
-		}
-
-		// Skip if we've already tried this proxy
-		if triedProxies[selectedProxy.ID] {
-			continue
-		}
-		triedProxies[selectedProxy.ID] = true
-
-		h.logger.Info("attempting CONNECT with proxy",
-			"source", "proxy",
-			"proxy_id", selectedProxy.ID,
-			"proxy_address", selectedProxy.Address,
-			"host", host,
-			"fallback_attempt", fallbackAttempt+1,
-		)
-
-		// Try this proxy with retries
-		conn, err := h.tryConnectWithRetries(selectedProxy, host, perProxyRetries)
-		duration := int(time.Since(startTime).Milliseconds())
-
-		if err != nil {
-			lastErr = fmt.Errorf("proxy %s failed after %d retries: %w", selectedProxy.Address, perProxyRetries, err)
-			h.logger.Warn("proxy CONNECT failed after all retries",
-				"source", "proxy",
-				"proxy_id", selectedProxy.ID,
-				"proxy_address", selectedProxy.Address,
-				"host", host,
-				"fallback_attempt", fallbackAttempt+1,
-				"retries_attempted", perProxyRetries,
-				"error", err,
-			)
-
-			// Record the failed CONNECT request
-			go func(proxyID int, proxyAddr string, failedDuration int, failErr error) {
-				recordCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				record := RequestRecord{
-					ProxyID:      proxyID,
-					ProxyAddress: proxyAddr,
-					RequestedURL: "CONNECT://" + host,
-					Method:       "CONNECT",
-					Success:      false,
-					ResponseTime: failedDuration,
-					ErrorMessage: failErr.Error(),
-					Timestamp:    startTime,
-				}
-				if recordErr := h.tracker.RecordRequest(recordCtx, record); recordErr != nil {
-					h.logger.Error("failed to record failed CONNECT request", "error", recordErr)
-				}
-			}(selectedProxy.ID, selectedProxy.Address, duration, err)
-
-			continue
-		}
-
-		h.logger.Info("proxy CONNECT succeeded",
-			"source", "proxy",
-			"proxy_id", selectedProxy.ID,
-			"proxy_address", selectedProxy.Address,
-			"host", host,
-			"fallback_attempt", fallbackAttempt+1,
-		)
-
-		// Record successful CONNECT request
-		go func(successDuration int) {
-			recordCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			record := RequestRecord{
-				ProxyID:      selectedProxy.ID,
-				ProxyAddress: selectedProxy.Address,
-				RequestedURL: "CONNECT://" + host,
-				Method:       "CONNECT",
-				Success:      true,
-				ResponseTime: successDuration,
-				StatusCode:   200, // CONNECT 200 OK
-				Timestamp:    startTime,
-			}
-			if recordErr := h.tracker.RecordRequest(recordCtx, record); recordErr != nil {
-				h.logger.Error("failed to record successful CONNECT request", "error", recordErr)
-			}
-		}(duration)
-
-		// Success!
-		return conn, selectedProxy.ID, nil
-	}
-
-	return nil, 0, fmt.Errorf("all proxies failed for CONNECT, last error: %w", lastErr)
-}
-
-// tryConnectWithRetries attempts to connect through a specific proxy with retries
-func (h *UpstreamProxyHandler) tryConnectWithRetries(selectedProxy *models.Proxy, host string, maxRetries int) (net.Conn, error) {
-	var lastErr error
-
-	for retry := 0; retry < maxRetries; retry++ {
-		h.logger.Info("attempting CONNECT",
-			"source", "proxy",
-			"proxy_id", selectedProxy.ID,
-			"proxy_address", selectedProxy.Address,
-			"host", host,
-			"retry", retry+1,
-			"max_retries", maxRetries,
-		)
-
-		// Try to connect through this proxy
-		conn, err := h.connectViaProxy(selectedProxy, host)
-		if err != nil {
-			lastErr = fmt.Errorf("proxy %s failed: %w", selectedProxy.Address, err)
-			h.logger.Warn("proxy CONNECT failed",
-				"source", "proxy",
-				"proxy_id", selectedProxy.ID,
-				"proxy_address", selectedProxy.Address,
-				"host", host,
-				"retry", retry+1,
-				"max_retries", maxRetries,
-				"error", err,
-			)
-
-			// If this is not the last retry, continue to next retry
-			if retry < maxRetries-1 {
-				continue
-			}
-		} else {
-			// Success!
-			h.logger.Info("proxy CONNECT succeeded",
-				"source", "proxy",
-				"proxy_id", selectedProxy.ID,
-				"proxy_address", selectedProxy.Address,
-				"host", host,
-				"retry", retry+1,
-			)
-			return conn, nil
-		}
-	}
-
-	return nil, lastErr
-}
-
-// connectViaProxy establishes a connection through a specific proxy
-func (h *UpstreamProxyHandler) connectViaProxy(proxy *models.Proxy, host string) (net.Conn, error) {
-	switch proxy.Protocol {
-	case "socks5":
-		// Create SOCKS5 dialer
-		var dialer proxyDialer.Dialer
-		var err error
-
-		if proxy.Username != nil && *proxy.Username != "" {
-			// Username exists, create auth
-			password := ""
-			if proxy.Password != nil {
-				password = *proxy.Password
-			}
-			auth := &proxyDialer.Auth{
-				User:     *proxy.Username,
-				Password: password,
-			}
-			dialer, err = proxyDialer.SOCKS5("tcp", proxy.Address, auth, proxyDialer.Direct)
-		} else {
-			dialer, err = proxyDialer.SOCKS5("tcp", proxy.Address, nil, proxyDialer.Direct)
-		}
-
-		if err != nil {
-			return nil, fmt.Errorf("failed to create SOCKS5 dialer: %w", err)
-		}
-
-		// Connect to target host through proxy
-		conn, err := dialer.Dial("tcp", host)
-		if err != nil {
-			return nil, fmt.Errorf("failed to connect to %s via SOCKS5 proxy %s: %w", host, proxy.Address, err)
-		}
-
-		return conn, nil
-
-	case "http", "https":
-		// For HTTP proxies, we need to send a CONNECT request
-		// This is more complex and requires HTTP client setup
-		return h.connectViaHTTPProxy(proxy, host)
-
-	default:
-		return nil, fmt.Errorf("unsupported proxy protocol for CONNECT: %s", proxy.Protocol)
-	}
-}
-
-// connectViaHTTPProxy establishes a connection through HTTP proxy using CONNECT method
-func (h *UpstreamProxyHandler) connectViaHTTPProxy(proxy *models.Proxy, host string) (net.Conn, error) {
-	// Increase timeout for CONNECT requests (some proxies like proxy.scrape.do need more time)
-	timeout := time.Duration(h.settings.Timeout) * time.Second
-	if timeout < 60*time.Second {
-		timeout = 60 * time.Second // Minimum 60 seconds for CONNECT requests
-	}
-
-	h.logger.Info("establishing HTTP CONNECT",
-		"source", "proxy",
-		"proxy_address", proxy.Address,
-		"target_host", host,
-		"timeout", timeout,
-	)
-
-	// Create a TCP connection to the proxy server
-	conn, err := net.DialTimeout("tcp", proxy.Address, timeout)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to proxy %s: %w", proxy.Address, err)
-	}
-
-	// Set read/write deadlines
-	deadline := time.Now().Add(timeout)
-	if err := conn.SetDeadline(deadline); err != nil {
-		conn.Close()
-		return nil, fmt.Errorf("failed to set connection deadline: %w", err)
-	}
-
-	// Build CONNECT request
-	// Format: CONNECT host:port HTTP/1.1
-	connectReq := fmt.Sprintf("CONNECT %s HTTP/1.1\r\n", host)
-	connectReq += fmt.Sprintf("Host: %s\r\n", host)
-
-	// Add proxy authentication if credentials are provided
-	if proxy.Username != nil && *proxy.Username != "" {
-		password := ""
-		if proxy.Password != nil {
-			password = *proxy.Password
-		}
-		auth := *proxy.Username + ":" + password
-		encoded := base64.StdEncoding.EncodeToString([]byte(auth))
-		connectReq += fmt.Sprintf("Proxy-Authorization: Basic %s\r\n", encoded)
-
-		h.logger.Info("adding proxy authentication",
-			"source", "proxy",
-			"proxy_address", proxy.Address,
-			"username", *proxy.Username,
-		)
-	}
-
-	// Add standard headers
-	connectReq += "User-Agent: Rota-Proxy/1.0\r\n"
-	connectReq += "Proxy-Connection: Keep-Alive\r\n"
-	connectReq += "\r\n" // Empty line to end headers
-
-	h.logger.Info("sending CONNECT request",
-		"source", "proxy",
-		"proxy_address", proxy.Address,
-		"target_host", host,
-	)
-
-	// Send the CONNECT request
-	_, err = conn.Write([]byte(connectReq))
-	if err != nil {
-		conn.Close()
-		return nil, fmt.Errorf("failed to send CONNECT request: %w", err)
-	}
-
-	// Read the response (read until we get the full HTTP response line)
-	buf := make([]byte, 4096)
-	n, err := conn.Read(buf)
-	if err != nil {
-		conn.Close()
-		return nil, fmt.Errorf("failed to read CONNECT response: %w", err)
-	}
-
-	response := string(buf[:n])
-	h.logger.Info("received CONNECT response",
-		"source", "proxy",
-		"proxy_address", proxy.Address,
-		"response_preview", response[:min(200, len(response))],
-	)
-
-	// Parse the response line (first line should be "HTTP/1.x 200 ...")
-	lines := strings.Split(response, "\r\n")
-	if len(lines) == 0 {
-		conn.Close()
-		return nil, fmt.Errorf("empty CONNECT response from proxy")
-	}
-
-	statusLine := lines[0]
-
-	// Check for 200 status code
-	if !strings.Contains(statusLine, "200") {
-		conn.Close()
-		return nil, fmt.Errorf("CONNECT request failed: %s", statusLine)
-	}
-
-	// Clear the deadline after successful connection
-	if err := conn.SetDeadline(time.Time{}); err != nil {
-		conn.Close()
-		return nil, fmt.Errorf("failed to clear connection deadline: %w", err)
-	}
-
-	h.logger.Info("CONNECT tunnel established",
-		"source", "proxy",
-		"proxy_address", proxy.Address,
-		"target_host", host,
-	)
-
-	// Connection established successfully
-	return conn, nil
-}
-
-// min returns the minimum of two integers
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }
 
 // recordAsync records a proxy request asynchronously.
@@ -761,17 +592,4 @@ func (h *UpstreamProxyHandler) recordAsync(proxyID int, proxyAddr, url, method s
 		defer cancel()
 		h.tracker.RecordRequest(ctx, record) //nolint:errcheck
 	}()
-}
-
-// badGateway returns a 502 Bad Gateway response
-func (h *UpstreamProxyHandler) badGateway(message string) *http.Response {
-	resp := &http.Response{
-		StatusCode: http.StatusBadGateway,
-		ProtoMajor: 1,
-		ProtoMinor: 1,
-		Header:     make(http.Header),
-		Body:       http.NoBody,
-	}
-	resp.Header.Set("Content-Type", "text/plain")
-	return resp
 }

--- a/core/internal/proxy/middleware.go
+++ b/core/internal/proxy/middleware.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/alpkeskin/rota/core/internal/models"
-	"github.com/elazarl/goproxy"
 	"golang.org/x/time/rate"
 )
 
@@ -39,7 +38,7 @@ func (m *AuthMiddleware) UpdateSettings(settings models.AuthenticationSettings) 
 }
 
 // HandleRequest validates proxy authentication for HTTP requests
-func (m *AuthMiddleware) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (m *AuthMiddleware) HandleRequest(req *http.Request) (*http.Request, *http.Response) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -84,8 +83,8 @@ func (m *AuthMiddleware) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx)
 }
 
 // HandleConnect validates proxy authentication for HTTPS CONNECT requests
-func (m *AuthMiddleware) HandleConnect(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-	return m.HandleRequest(req, ctx)
+func (m *AuthMiddleware) HandleConnect(req *http.Request) (*http.Request, *http.Response) {
+	return m.HandleRequest(req)
 }
 
 // unauthorized returns a 407 Proxy Authentication Required response
@@ -133,7 +132,7 @@ func (m *RateLimitMiddleware) UpdateSettings(settings models.RateLimitSettings) 
 }
 
 // HandleRequest validates rate limits for HTTP requests
-func (m *RateLimitMiddleware) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (m *RateLimitMiddleware) HandleRequest(req *http.Request) (*http.Request, *http.Response) {
 	if !m.enabled {
 		return req, nil
 	}
@@ -150,8 +149,8 @@ func (m *RateLimitMiddleware) HandleRequest(req *http.Request, ctx *goproxy.Prox
 }
 
 // HandleConnect validates rate limits for HTTPS CONNECT requests
-func (m *RateLimitMiddleware) HandleConnect(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-	return m.HandleRequest(req, ctx)
+func (m *RateLimitMiddleware) HandleConnect(req *http.Request) (*http.Request, *http.Response) {
+	return m.HandleRequest(req)
 }
 
 // allow checks if the request is allowed based on rate limiting

--- a/core/internal/proxy/middleware_test.go
+++ b/core/internal/proxy/middleware_test.go
@@ -1,0 +1,224 @@
+package proxy
+
+import (
+	"encoding/base64"
+	"net/http"
+	"testing"
+
+	"github.com/alpkeskin/rota/core/internal/models"
+)
+
+func basicAuth(user, pass string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+pass))
+}
+
+// ── AuthMiddleware ──────────────────────────────────────────────────────────
+
+func TestAuthMiddleware_Disabled(t *testing.T) {
+	m := NewAuthMiddleware(models.AuthenticationSettings{Enabled: false})
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+	_, resp := m.HandleRequest(req)
+	if resp != nil {
+		t.Fatalf("expected nil reject, got status %d", resp.StatusCode)
+	}
+}
+
+func TestAuthMiddleware_ValidCredentials(t *testing.T) {
+	m := NewAuthMiddleware(models.AuthenticationSettings{
+		Enabled:  true,
+		Username: "admin",
+		Password: "secret",
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Set("Proxy-Authorization", basicAuth("admin", "secret"))
+
+	_, resp := m.HandleRequest(req)
+	if resp != nil {
+		t.Fatalf("expected auth to pass, got status %d", resp.StatusCode)
+	}
+}
+
+func TestAuthMiddleware_InvalidCredentials(t *testing.T) {
+	m := NewAuthMiddleware(models.AuthenticationSettings{
+		Enabled:  true,
+		Username: "admin",
+		Password: "secret",
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Set("Proxy-Authorization", basicAuth("admin", "wrong"))
+
+	_, resp := m.HandleRequest(req)
+	if resp == nil || resp.StatusCode != http.StatusProxyAuthRequired {
+		t.Fatalf("expected 407, got %v", resp)
+	}
+}
+
+func TestAuthMiddleware_MissingHeader(t *testing.T) {
+	m := NewAuthMiddleware(models.AuthenticationSettings{
+		Enabled:  true,
+		Username: "admin",
+		Password: "secret",
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+	_, resp := m.HandleRequest(req)
+	if resp == nil || resp.StatusCode != http.StatusProxyAuthRequired {
+		t.Fatalf("expected 407, got %v", resp)
+	}
+}
+
+func TestAuthMiddleware_UpdateSettings(t *testing.T) {
+	m := NewAuthMiddleware(models.AuthenticationSettings{
+		Enabled:  true,
+		Username: "admin",
+		Password: "old",
+	})
+
+	// Old password works
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Set("Proxy-Authorization", basicAuth("admin", "old"))
+	_, resp := m.HandleRequest(req)
+	if resp != nil {
+		t.Fatal("old password should work")
+	}
+
+	// Update credentials
+	m.UpdateSettings(models.AuthenticationSettings{
+		Enabled:  true,
+		Username: "admin",
+		Password: "new",
+	})
+
+	// Old password fails
+	req2, _ := http.NewRequest("GET", "http://example.com", nil)
+	req2.Header.Set("Proxy-Authorization", basicAuth("admin", "old"))
+	_, resp2 := m.HandleRequest(req2)
+	if resp2 == nil || resp2.StatusCode != http.StatusProxyAuthRequired {
+		t.Fatal("old password should fail after update")
+	}
+
+	// New password works
+	req3, _ := http.NewRequest("GET", "http://example.com", nil)
+	req3.Header.Set("Proxy-Authorization", basicAuth("admin", "new"))
+	_, resp3 := m.HandleRequest(req3)
+	if resp3 != nil {
+		t.Fatal("new password should work")
+	}
+}
+
+func TestAuthMiddleware_StripHeader(t *testing.T) {
+	m := NewAuthMiddleware(models.AuthenticationSettings{
+		Enabled:  true,
+		Username: "admin",
+		Password: "secret",
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.Header.Set("Proxy-Authorization", basicAuth("admin", "secret"))
+
+	req, _ = m.HandleRequest(req)
+	if req.Header.Get("Proxy-Authorization") != "" {
+		t.Fatal("Proxy-Authorization header should be stripped after auth")
+	}
+}
+
+// ── RateLimitMiddleware ─────────────────────────────────────────────────────
+
+func TestRateLimitMiddleware_Disabled(t *testing.T) {
+	m := NewRateLimitMiddleware(models.RateLimitSettings{Enabled: false})
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+	_, resp := m.HandleRequest(req)
+	if resp != nil {
+		t.Fatalf("expected nil reject, got status %d", resp.StatusCode)
+	}
+}
+
+func TestRateLimitMiddleware_AllowsUnderLimit(t *testing.T) {
+	m := NewRateLimitMiddleware(models.RateLimitSettings{
+		Enabled:     true,
+		Interval:    1,    // 1 second
+		MaxRequests: 100,  // 100 per second
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.RemoteAddr = "192.168.1.1:12345"
+
+	// First 10 requests should pass easily
+	for i := 0; i < 10; i++ {
+		_, resp := m.HandleRequest(req)
+		if resp != nil {
+			t.Fatalf("request %d should be allowed, got status %d", i, resp.StatusCode)
+		}
+	}
+}
+
+func TestRateLimitMiddleware_BlocksOverLimit(t *testing.T) {
+	m := NewRateLimitMiddleware(models.RateLimitSettings{
+		Enabled:     true,
+		Interval:    1,  // 1 second
+		MaxRequests: 5,  // only 5 burst
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	req.RemoteAddr = "10.0.0.1:12345"
+
+	// Exhaust the burst
+	for i := 0; i < 5; i++ {
+		m.HandleRequest(req)
+	}
+
+	// Next request should be blocked
+	_, resp := m.HandleRequest(req)
+	if resp == nil || resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %v", resp)
+	}
+}
+
+func TestRateLimitMiddleware_PerIP(t *testing.T) {
+	m := NewRateLimitMiddleware(models.RateLimitSettings{
+		Enabled:     true,
+		Interval:    1,
+		MaxRequests: 2,  // tiny burst
+	})
+
+	// Exhaust limit for IP1
+	req1, _ := http.NewRequest("GET", "http://example.com", nil)
+	req1.RemoteAddr = "1.1.1.1:1111"
+	m.HandleRequest(req1)
+	m.HandleRequest(req1)
+	_, resp1 := m.HandleRequest(req1)
+	if resp1 == nil || resp1.StatusCode != http.StatusTooManyRequests {
+		t.Fatal("IP1 should be rate-limited")
+	}
+
+	// IP2 should still be allowed
+	req2, _ := http.NewRequest("GET", "http://example.com", nil)
+	req2.RemoteAddr = "2.2.2.2:2222"
+	_, resp2 := m.HandleRequest(req2)
+	if resp2 != nil {
+		t.Fatal("IP2 should not be rate-limited")
+	}
+}
+
+func TestRateLimitMiddleware_Cleanup(t *testing.T) {
+	m := NewRateLimitMiddleware(models.RateLimitSettings{
+		Enabled:     true,
+		Interval:    1,
+		MaxRequests: 100,
+	})
+
+	// Add many IPs
+	for i := 0; i < 100; i++ {
+		req, _ := http.NewRequest("GET", "http://example.com", nil)
+		req.RemoteAddr = "10.0.0.1:12345"
+		m.HandleRequest(req)
+	}
+
+	// Cleanup should not panic or error
+	m.CleanupLimiters()
+}

--- a/core/internal/proxy/rotation.go
+++ b/core/internal/proxy/rotation.go
@@ -57,8 +57,6 @@ func (s *RandomSelector) Select(ctx context.Context) (*models.Proxy, error) {
 		return nil, fmt.Errorf("failed to generate random number: %w", err)
 	}
 
-	fmt.Printf("[PROXY POOL] Selected proxy: %s\n", s.proxies[n.Int64()].Address)
-
 	return s.proxies[n.Int64()], nil
 }
 

--- a/core/internal/proxy/server.go
+++ b/core/internal/proxy/server.go
@@ -3,19 +3,72 @@ package proxy
 import (
 	"context"
 	"fmt"
-	"net"
+	"io"
 	"net/http"
 	"time"
 
 	"github.com/alpkeskin/rota/core/internal/database"
 	"github.com/alpkeskin/rota/core/internal/repository"
 	"github.com/alpkeskin/rota/core/pkg/logger"
-	"github.com/elazarl/goproxy"
 )
+
+// proxyRouter is the core HTTP handler that dispatches incoming proxy requests.
+// It replaces the goproxy library with a minimal, zero-dependency implementation
+// that supports both HTTP forwarding and HTTPS CONNECT tunneling.
+type proxyRouter struct {
+	upstream    *UpstreamProxyHandler
+	userAuthMw  *UserAuthMiddleware
+	rateLimitMw *RateLimitMiddleware
+	logger      *logger.Logger
+}
+
+// ServeHTTP dispatches incoming requests through the middleware chain
+// and routes them to the appropriate handler based on method.
+func (p *proxyRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// 1. User auth middleware (sets PoolChain in context or falls back to legacy)
+	r, reject := p.userAuthMw.HandleRequest(r)
+	if reject != nil {
+		writeHTTPResponse(w, reject)
+		return
+	}
+
+	// 2. Rate limit middleware
+	r, reject = p.rateLimitMw.HandleRequest(r)
+	if reject != nil {
+		writeHTTPResponse(w, reject)
+		return
+	}
+
+	// 3. Dispatch based on method
+	if r.Method == http.MethodConnect {
+		p.upstream.HandleConnectRequest(w, r)
+	} else {
+		p.upstream.HandleHTTPRequest(w, r)
+	}
+}
+
+// writeHTTPResponse translates a middleware-returned *http.Response into
+// http.ResponseWriter calls. This bridges the middleware return convention
+// (returning *http.Response for reject) with the stdlib interface.
+func writeHTTPResponse(w http.ResponseWriter, resp *http.Response) {
+	if resp == nil {
+		return
+	}
+	for k, vv := range resp.Header {
+		for _, v := range vv {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	if resp.Body != nil {
+		io.Copy(w, resp.Body) //nolint:errcheck
+		resp.Body.Close()
+	}
+}
 
 // Server represents the proxy server
 type Server struct {
-	proxy           *goproxy.ProxyHttpServer
+	router          *proxyRouter
 	server          *http.Server
 	logger          *logger.Logger
 	port            int
@@ -75,80 +128,25 @@ func New(
 	// Create user-aware auth middleware (pool-based routing)
 	userAuthMw := NewUserAuthMiddleware(userRepo, poolRepo, db, authMiddleware, &settings.Rotation, log)
 
-	// Create goproxy instance
-	proxyServer := goproxy.NewProxyHttpServer()
-	proxyServer.Verbose = log.Logger.Enabled(context.Background(), -4) // Enable verbose if debug level
-
-	// CRITICAL: Set ConnectDial to route HTTPS through upstream proxy
-	// This is called for ALL CONNECT requests (HTTPS tunneling)
-	// We store the last pool chain seen by the CONNECT handler in a short-lived map.
-	proxyServer.ConnectDial = func(network string, addr string) (net.Conn, error) {
-		log.Info("ConnectDial called",
-			"source", "proxy",
-			"network", network,
-			"addr", addr,
-		)
-		conn, _, err := handler.ConnectThroughProxyForDial(addr)
-		if err != nil {
-			log.Error("ConnectDial failed", "source", "proxy", "addr", addr, "error", err)
-			return nil, err
-		}
-		log.Info("ConnectDial succeeded", "source", "proxy", "addr", addr)
-		return conn, nil
+	// Create the proxy router
+	router := &proxyRouter{
+		upstream:    handler,
+		userAuthMw:  userAuthMw,
+		rateLimitMw: rateLimitMw,
+		logger:      log,
 	}
 
-	// Setup handlers with middleware chain
-	// Order: Auth -> RateLimit -> Handler
-
-	// HTTP requests — userAuthMw handles both legacy and pool-based auth
-	proxyServer.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-		// User-aware auth: sets PoolChain in context or falls back to legacy auth
-		newReq, resp := userAuthMw.HandleRequest(req, ctx)
-		if resp != nil {
-			return newReq, resp
-		}
-		req = newReq
-
-		// Rate limiting middleware
-		if req, resp := rateLimitMw.HandleRequest(req, ctx); resp != nil {
-			return req, resp
-		}
-
-		// Main handler (checks for PoolChain in context automatically)
-		return handler.HandleRequest(req, ctx)
-	})
-
-	// HTTPS CONNECT requests
-	proxyServer.OnRequest().HandleConnect(goproxy.FuncHttpsHandler(func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
-		// User-aware auth
-		newReq, resp := userAuthMw.HandleConnect(ctx.Req, ctx)
-		if resp != nil {
-			ctx.Resp = resp
-			return goproxy.RejectConnect, host
-		}
-		ctx.Req = newReq
-
-		// Rate limiting middleware
-		if _, resp := rateLimitMw.HandleConnect(ctx.Req, ctx); resp != nil {
-			ctx.Resp = resp
-			return goproxy.RejectConnect, host
-		}
-
-		// If a PoolChain is in context, use it for CONNECT too.
-		// ConnectDial below will use the chain for the actual dial.
-		return goproxy.OkConnect, host
-	}))
-
+	// WriteTimeout must be 0 for CONNECT tunnels (they are long-lived).
+	// HTTP path enforces timeouts via context.
 	httpServer := &http.Server{
-		Addr:         fmt.Sprintf(":%d", port),
-		Handler:      proxyServer,
-		ReadTimeout:  time.Duration(settings.Rotation.Timeout) * time.Second,
-		WriteTimeout: time.Duration(settings.Rotation.Timeout) * time.Second,
-		IdleTimeout:  60 * time.Second,
+		Addr:        fmt.Sprintf(":%d", port),
+		Handler:     router,
+		ReadTimeout: time.Duration(settings.Rotation.Timeout) * time.Second,
+		IdleTimeout: 60 * time.Second,
 	}
 
 	s := &Server{
-		proxy:          proxyServer,
+		router:         router,
 		server:         httpServer,
 		logger:         log,
 		port:           port,
@@ -181,7 +179,7 @@ func (s *Server) startBackgroundTasks() {
 				if err := s.selector.Refresh(ctx); err != nil {
 					s.logger.Error("failed to refresh proxy list", "error", err)
 				} else {
-					s.logger.Info("proxy list refreshed")
+					s.logger.Debug("proxy list refreshed")
 				}
 				cancel()
 			case <-s.stopChan:
@@ -197,7 +195,7 @@ func (s *Server) startBackgroundTasks() {
 			select {
 			case <-s.cleanupTicker.C:
 				s.rateLimitMw.CleanupLimiters()
-				s.logger.Info("cleaned up rate limiters")
+				s.logger.Debug("cleaned up rate limiters")
 			case <-s.stopChan:
 				return
 			}
@@ -220,7 +218,6 @@ func (s *Server) Start() error {
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.logger.Info("shutting down proxy server")
 
-	// Stop background tasks
 	close(s.stopChan)
 	if s.refreshTicker != nil {
 		s.refreshTicker.Stop()

--- a/core/internal/proxy/server_test.go
+++ b/core/internal/proxy/server_test.go
@@ -1,0 +1,191 @@
+package proxy
+
+import (
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/alpkeskin/rota/core/internal/models"
+	"github.com/alpkeskin/rota/core/pkg/logger"
+)
+
+// mockHandler is a minimal UpstreamProxyHandler replacement for router tests.
+type mockHandler struct {
+	httpCalled    bool
+	connectCalled bool
+}
+
+func (m *mockHandler) HandleHTTPRequest(w http.ResponseWriter, r *http.Request) {
+	m.httpCalled = true
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("proxied"))
+}
+
+func (m *mockHandler) HandleConnectRequest(w http.ResponseWriter, r *http.Request) {
+	m.connectCalled = true
+	w.WriteHeader(http.StatusOK)
+}
+
+func newTestRouter(auth *AuthMiddleware, rl *RateLimitMiddleware, log *logger.Logger) (*proxyRouter, *mockHandler) {
+	handler := &mockHandler{}
+
+	// We can't use a real UpstreamProxyHandler without DB, so we test the
+	// router dispatch + middleware logic using a real proxyRouter with
+	// a real AuthMiddleware/RateLimitMiddleware but test dispatch via
+	// integration with the full proxyRouter.
+
+	return &proxyRouter{
+		userAuthMw:  nil, // will be set per test
+		rateLimitMw: rl,
+		logger:      log,
+	}, handler
+}
+
+func TestProxyRouter_AuthReject(t *testing.T) {
+	log := logger.New("error")
+
+	authMw := NewAuthMiddleware(models.AuthenticationSettings{
+		Enabled:  true,
+		Username: "admin",
+		Password: "secret",
+	})
+	rlMw := NewRateLimitMiddleware(models.RateLimitSettings{Enabled: false})
+
+	// Create a minimal proxyRouter without the full handler chain.
+	// We test that middleware rejection works at the router level.
+	router := &proxyRouter{
+		userAuthMw: NewTestUserAuthMiddleware(authMw),
+		rateLimitMw: rlMw,
+		upstream:    nil, // won't be reached due to auth rejection
+		logger:      log,
+	}
+
+	// No auth header → should get 407
+	req := httptest.NewRequest("GET", "http://example.com/path", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusProxyAuthRequired {
+		t.Fatalf("expected 407, got %d", w.Code)
+	}
+}
+
+func TestProxyRouter_RateLimitReject(t *testing.T) {
+	log := logger.New("error")
+
+	authMw := NewAuthMiddleware(models.AuthenticationSettings{Enabled: false})
+	rlMw := NewRateLimitMiddleware(models.RateLimitSettings{
+		Enabled:     true,
+		Interval:    1,
+		MaxRequests: 1,
+	})
+
+	// Test rate limiting at the middleware level directly (without full router)
+	// to avoid nil pointer on selector/tracker.
+	req1, _ := http.NewRequest("GET", "http://example.com/", nil)
+	req1.RemoteAddr = "5.5.5.5:5555"
+
+	// Auth passes (disabled)
+	_, authResp := authMw.HandleRequest(req1)
+	if authResp != nil {
+		t.Fatal("auth should be disabled")
+	}
+
+	// First request passes rate limit
+	_, rlResp := rlMw.HandleRequest(req1)
+	if rlResp != nil {
+		t.Fatal("first request should pass rate limit")
+	}
+
+	// Second request should be blocked
+	req2, _ := http.NewRequest("GET", "http://example.com/", nil)
+	req2.RemoteAddr = "5.5.5.5:5555"
+	_, rlResp2 := rlMw.HandleRequest(req2)
+	if rlResp2 == nil || rlResp2.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %v", rlResp2)
+	}
+
+	// Verify the full router integration with auth rejection still works
+	router := &proxyRouter{
+		userAuthMw:  NewTestUserAuthMiddleware(authMw),
+		rateLimitMw: NewRateLimitMiddleware(models.RateLimitSettings{Enabled: false}),
+		upstream:    nil,
+		logger:      log,
+	}
+	_ = router // router tested in other tests
+}
+
+func TestProxyRouter_AuthPassesWithValidCredentials(t *testing.T) {
+	// Test that AuthMiddleware passes valid credentials directly (without UserAuthMiddleware DB)
+	authMw := NewAuthMiddleware(models.AuthenticationSettings{
+		Enabled:  true,
+		Username: "user",
+		Password: "pass",
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com/", nil)
+	req.Header.Set("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("user:pass")))
+
+	_, resp := authMw.HandleRequest(req)
+	if resp != nil {
+		t.Fatalf("expected auth to pass with valid credentials, got %d", resp.StatusCode)
+	}
+
+	// Invalid credentials should be rejected
+	req2, _ := http.NewRequest("GET", "http://example.com/", nil)
+	req2.Header.Set("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("user:wrong")))
+
+	_, resp2 := authMw.HandleRequest(req2)
+	if resp2 == nil || resp2.StatusCode != http.StatusProxyAuthRequired {
+		t.Fatal("expected 407 for wrong credentials")
+	}
+}
+
+func TestWriteHTTPResponse(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     make(http.Header),
+		Body:       http.NoBody,
+	}
+	resp.Header.Set("X-Test", "value")
+
+	w := httptest.NewRecorder()
+	writeHTTPResponse(w, resp)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if w.Header().Get("X-Test") != "value" {
+		t.Fatal("expected X-Test header")
+	}
+}
+
+func TestWriteHTTPResponse_WithBody(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(http.NoBody),
+	}
+
+	w := httptest.NewRecorder()
+	writeHTTPResponse(w, resp)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+// NewTestUserAuthMiddleware creates a UserAuthMiddleware that only does
+// legacy auth (no DB, no proxy users). For testing the router dispatch.
+func NewTestUserAuthMiddleware(legacy *AuthMiddleware) *UserAuthMiddleware {
+	return &UserAuthMiddleware{
+		legacy: legacy,
+		cache:  make(map[string]userEntry),
+	}
+}

--- a/core/internal/proxy/splice_linux.go
+++ b/core/internal/proxy/splice_linux.go
@@ -1,0 +1,129 @@
+//go:build linux
+
+package proxy
+
+import (
+	"net"
+	"syscall"
+)
+
+// trySplice attempts zero-copy transfer using Linux splice(2) syscall.
+// Returns (true, err) if splice was used, (false, nil) if caller should
+// fall back to io.Copy (e.g. non-TCP connections).
+func trySplice(dst, src net.Conn) (bool, error) {
+	// Both connections must expose raw file descriptors via syscall.Conn.
+	srcSC, ok := src.(syscall.Conn)
+	if !ok {
+		return false, nil
+	}
+	dstSC, ok := dst.(syscall.Conn)
+	if !ok {
+		return false, nil
+	}
+
+	srcRC, err := srcSC.SyscallConn()
+	if err != nil {
+		return false, nil
+	}
+	dstRC, err := dstSC.SyscallConn()
+	if err != nil {
+		return false, nil
+	}
+
+	// Create a kernel pipe as the intermediate buffer for splice.
+	var pipeFDs [2]int
+	if err := syscall.Pipe2(pipeFDs[:], syscall.O_NONBLOCK|syscall.O_CLOEXEC); err != nil {
+		return false, nil // pipe creation failed, fall back
+	}
+	pipeR := pipeFDs[0]
+	pipeW := pipeFDs[1]
+	defer syscall.Close(pipeR)
+	defer syscall.Close(pipeW)
+
+	// Increase pipe buffer to 64KB for better throughput.
+	fcntl(pipeR, syscall.F_SETPIPE_SZ, 65536)
+
+	var spliceErr error
+
+	// The outer Control call gives us the src fd.
+	srcRC.Read(func(srcFD uintptr) bool {
+		// The inner Control call gives us the dst fd.
+		dstRC.Write(func(dstFD uintptr) bool {
+			spliceErr = splicePump(int(srcFD), int(dstFD), pipeR, pipeW)
+			return true
+		})
+		return true
+	})
+
+	if spliceErr != nil {
+		return true, spliceErr
+	}
+	return true, nil
+}
+
+// splicePump moves data: src → pipeW → pipeR → dst using splice(2).
+// Runs until src returns EOF (n==0) or an error occurs.
+func splicePump(srcFD, dstFD, pipeR, pipeW int) error {
+	for {
+		// Move data from src socket into the pipe write end.
+		n, err := syscall.Splice(srcFD, nil, pipeW, nil, 65536, syscall.SPLICE_F_MOVE|syscall.SPLICE_F_NONBLOCK)
+		if err != nil {
+			if err == syscall.EAGAIN {
+				// Source not ready yet — use poll to wait.
+				if pollErr := pollFD(srcFD, false); pollErr != nil {
+					return pollErr
+				}
+				continue
+			}
+			if n == 0 {
+				return nil // EOF
+			}
+			return err
+		}
+		if n == 0 {
+			return nil // EOF — src closed
+		}
+
+		// Drain the pipe into the dst socket.
+		for written := int64(0); written < n; {
+			w, err := syscall.Splice(pipeR, nil, dstFD, nil, int(n-written), syscall.SPLICE_F_MOVE|syscall.SPLICE_F_NONBLOCK)
+			if err != nil {
+				if err == syscall.EAGAIN {
+					if pollErr := pollFD(dstFD, true); pollErr != nil {
+						return pollErr
+					}
+					continue
+				}
+				return err
+			}
+			written += w
+		}
+	}
+}
+
+// pollFD waits for a file descriptor to become ready for reading or writing.
+func pollFD(fd int, write bool) error {
+	events := int16(syscall.POLLIN)
+	if write {
+		events = syscall.POLLOUT
+	}
+	fds := []syscall.PollFd{{Fd: int32(fd), Events: events}}
+	for {
+		n, err := syscall.Poll(fds, 60000) // 60s timeout
+		if err != nil {
+			if err == syscall.EINTR {
+				continue
+			}
+			return err
+		}
+		if n == 0 {
+			return syscall.ETIMEDOUT
+		}
+		return nil
+	}
+}
+
+// fcntl is a thin wrapper for fcntl(2).
+func fcntl(fd int, cmd int, arg int) {
+	syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), uintptr(cmd), uintptr(arg)) //nolint:errcheck
+}

--- a/core/internal/proxy/splice_linux.go
+++ b/core/internal/proxy/splice_linux.go
@@ -4,50 +4,53 @@ package proxy
 
 import (
 	"net"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // trySplice attempts zero-copy transfer using Linux splice(2) syscall.
 // Returns (true, err) if splice was used, (false, nil) if caller should
 // fall back to io.Copy (e.g. non-TCP connections).
 func trySplice(dst, src net.Conn) (bool, error) {
-	// Both connections must expose raw file descriptors via syscall.Conn.
-	srcSC, ok := src.(syscall.Conn)
+	// Both connections must be raw TCP to get file descriptors.
+	srcTCP, ok := src.(*net.TCPConn)
 	if !ok {
 		return false, nil
 	}
-	dstSC, ok := dst.(syscall.Conn)
+	dstTCP, ok := dst.(*net.TCPConn)
 	if !ok {
 		return false, nil
 	}
 
-	srcRC, err := srcSC.SyscallConn()
+	// Get raw file descriptors via SyscallConn (no dup, keeps non-blocking mode).
+	srcRC, err := srcTCP.SyscallConn()
 	if err != nil {
 		return false, nil
 	}
-	dstRC, err := dstSC.SyscallConn()
+	dstRC, err := dstTCP.SyscallConn()
 	if err != nil {
 		return false, nil
 	}
 
 	// Create a kernel pipe as the intermediate buffer for splice.
-	var pipeFDs [2]int
-	if err := syscall.Pipe2(pipeFDs[:], syscall.O_NONBLOCK|syscall.O_CLOEXEC); err != nil {
-		return false, nil // pipe creation failed, fall back
+	pipeFDs := make([]int, 2)
+	if err := unix.Pipe2(pipeFDs, unix.O_NONBLOCK|unix.O_CLOEXEC); err != nil {
+		return false, nil
 	}
 	pipeR := pipeFDs[0]
 	pipeW := pipeFDs[1]
-	defer syscall.Close(pipeR)
-	defer syscall.Close(pipeW)
+	defer unix.Close(pipeR)
+	defer unix.Close(pipeW)
 
 	// Increase pipe buffer to 64KB for better throughput.
-	fcntl(pipeR, syscall.F_SETPIPE_SZ, 65536)
+	// Use raw IoctlSetInt instead of Fcntl which may not be available on all archs.
+	unix.IoctlSetInt(pipeR, unix.F_SETPIPE_SZ, 65536) //nolint:errcheck
 
 	var spliceErr error
 
-	// The outer Control call gives us the src fd.
+	// The outer Read call gives us the src fd.
 	srcRC.Read(func(srcFD uintptr) bool {
-		// The inner Control call gives us the dst fd.
+		// The inner Write call gives us the dst fd.
 		dstRC.Write(func(dstFD uintptr) bool {
 			spliceErr = splicePump(int(srcFD), int(dstFD), pipeR, pipeW)
 			return true
@@ -64,12 +67,13 @@ func trySplice(dst, src net.Conn) (bool, error) {
 // splicePump moves data: src → pipeW → pipeR → dst using splice(2).
 // Runs until src returns EOF (n==0) or an error occurs.
 func splicePump(srcFD, dstFD, pipeR, pipeW int) error {
+	const spliceFlags = unix.SPLICE_F_MOVE | unix.SPLICE_F_NONBLOCK
+
 	for {
 		// Move data from src socket into the pipe write end.
-		n, err := syscall.Splice(srcFD, nil, pipeW, nil, 65536, syscall.SPLICE_F_MOVE|syscall.SPLICE_F_NONBLOCK)
+		n, err := unix.Splice(srcFD, nil, pipeW, nil, 65536, spliceFlags)
 		if err != nil {
-			if err == syscall.EAGAIN {
-				// Source not ready yet — use poll to wait.
+			if err == unix.EAGAIN {
 				if pollErr := pollFD(srcFD, false); pollErr != nil {
 					return pollErr
 				}
@@ -85,10 +89,10 @@ func splicePump(srcFD, dstFD, pipeR, pipeW int) error {
 		}
 
 		// Drain the pipe into the dst socket.
-		for written := int64(0); written < n; {
-			w, err := syscall.Splice(pipeR, nil, dstFD, nil, int(n-written), syscall.SPLICE_F_MOVE|syscall.SPLICE_F_NONBLOCK)
+		for written := int64(0); written < int64(n); {
+			w, err := unix.Splice(pipeR, nil, dstFD, nil, int(int64(n)-written), spliceFlags)
 			if err != nil {
-				if err == syscall.EAGAIN {
+				if err == unix.EAGAIN {
 					if pollErr := pollFD(dstFD, true); pollErr != nil {
 						return pollErr
 					}
@@ -96,34 +100,29 @@ func splicePump(srcFD, dstFD, pipeR, pipeW int) error {
 				}
 				return err
 			}
-			written += w
+			written += int64(w)
 		}
 	}
 }
 
 // pollFD waits for a file descriptor to become ready for reading or writing.
 func pollFD(fd int, write bool) error {
-	events := int16(syscall.POLLIN)
+	events := int16(unix.POLLIN)
 	if write {
-		events = syscall.POLLOUT
+		events = unix.POLLOUT
 	}
-	fds := []syscall.PollFd{{Fd: int32(fd), Events: events}}
+	fds := []unix.PollFd{{Fd: int32(fd), Events: events}}
 	for {
-		n, err := syscall.Poll(fds, 60000) // 60s timeout
+		n, err := unix.Poll(fds, 60000) // 60s timeout
 		if err != nil {
-			if err == syscall.EINTR {
+			if err == unix.EINTR {
 				continue
 			}
 			return err
 		}
 		if n == 0 {
-			return syscall.ETIMEDOUT
+			return unix.ETIMEDOUT
 		}
 		return nil
 	}
-}
-
-// fcntl is a thin wrapper for fcntl(2).
-func fcntl(fd int, cmd int, arg int) {
-	syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), uintptr(cmd), uintptr(arg)) //nolint:errcheck
 }

--- a/core/internal/proxy/splice_other.go
+++ b/core/internal/proxy/splice_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package proxy
+
+import "net"
+
+// trySplice is a no-op on non-Linux platforms.
+// Returns (false, nil) so the caller falls back to io.Copy.
+func trySplice(dst, src net.Conn) (bool, error) {
+	return false, nil
+}

--- a/core/internal/proxy/transport.go
+++ b/core/internal/proxy/transport.go
@@ -5,12 +5,32 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/alpkeskin/rota/core/internal/models"
 	"h12.io/socks"
 	proxyDialer "golang.org/x/net/proxy"
 )
+
+// transportCache caches *http.Transport per proxy address+protocol to avoid
+// creating a new transport (and new connection pool) for every request.
+var transportCache sync.Map
+
+// GetOrCreateTransport returns a cached transport for the given proxy,
+// or creates and caches a new one.
+func GetOrCreateTransport(p *models.Proxy) (*http.Transport, error) {
+	key := p.Protocol + "://" + p.Address
+	if t, ok := transportCache.Load(key); ok {
+		return t.(*http.Transport), nil
+	}
+	t, err := CreateProxyTransport(p)
+	if err != nil {
+		return nil, err
+	}
+	actual, _ := transportCache.LoadOrStore(key, t)
+	return actual.(*http.Transport), nil
+}
 
 // CreateProxyTransport creates an HTTP transport configured for the given proxy
 // This is shared between proxy handler and health checker

--- a/core/internal/proxy/transport_test.go
+++ b/core/internal/proxy/transport_test.go
@@ -1,0 +1,113 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/alpkeskin/rota/core/internal/models"
+)
+
+func TestGetOrCreateTransport_CachesPerProxy(t *testing.T) {
+	p := &models.Proxy{
+		ID:       1,
+		Address:  "127.0.0.1:8080",
+		Protocol: "http",
+	}
+
+	t1, err := GetOrCreateTransport(p)
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	t2, err := GetOrCreateTransport(p)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	if t1 != t2 {
+		t.Fatal("expected same transport instance from cache")
+	}
+}
+
+func TestGetOrCreateTransport_DifferentProxies(t *testing.T) {
+	p1 := &models.Proxy{
+		ID:       1,
+		Address:  "127.0.0.1:8081",
+		Protocol: "http",
+	}
+	p2 := &models.Proxy{
+		ID:       2,
+		Address:  "127.0.0.1:8082",
+		Protocol: "http",
+	}
+
+	t1, err := GetOrCreateTransport(p1)
+	if err != nil {
+		t.Fatalf("proxy1: %v", err)
+	}
+
+	t2, err := GetOrCreateTransport(p2)
+	if err != nil {
+		t.Fatalf("proxy2: %v", err)
+	}
+
+	if t1 == t2 {
+		t.Fatal("expected different transport instances for different proxies")
+	}
+}
+
+func TestCreateProxyTransport_HTTP(t *testing.T) {
+	p := &models.Proxy{
+		Address:  "127.0.0.1:3128",
+		Protocol: "http",
+	}
+	tr, err := CreateProxyTransport(p)
+	if err != nil {
+		t.Fatalf("CreateProxyTransport: %v", err)
+	}
+	if tr.Proxy == nil {
+		t.Fatal("HTTP proxy transport should have Proxy function set")
+	}
+}
+
+func TestCreateProxyTransport_SOCKS5(t *testing.T) {
+	p := &models.Proxy{
+		Address:  "127.0.0.1:1080",
+		Protocol: "socks5",
+	}
+	tr, err := CreateProxyTransport(p)
+	if err != nil {
+		t.Fatalf("CreateProxyTransport: %v", err)
+	}
+	if tr.Dial == nil {
+		t.Fatal("SOCKS5 transport should have Dial function set")
+	}
+}
+
+func TestCreateProxyTransport_UnsupportedProtocol(t *testing.T) {
+	p := &models.Proxy{
+		Address:  "127.0.0.1:9999",
+		Protocol: "ftp",
+	}
+	_, err := CreateProxyTransport(p)
+	if err == nil {
+		t.Fatal("expected error for unsupported protocol")
+	}
+}
+
+func TestCreateProxyTransport_WithAuth(t *testing.T) {
+	user := "myuser"
+	pass := "mypass"
+	p := &models.Proxy{
+		Address:  "127.0.0.1:3128",
+		Protocol: "http",
+		Username: &user,
+		Password: &pass,
+	}
+	tr, err := CreateProxyTransport(p)
+	if err != nil {
+		t.Fatalf("CreateProxyTransport with auth: %v", err)
+	}
+	if tr.Proxy == nil {
+		t.Fatal("should have Proxy set")
+	}
+}

--- a/core/internal/proxy/tunnel.go
+++ b/core/internal/proxy/tunnel.go
@@ -1,0 +1,73 @@
+package proxy
+
+import (
+	"io"
+	"net"
+	"sync"
+)
+
+// BidirectionalCopy copies data between client and upstream in both directions
+// concurrently. It returns when either direction encounters an error or EOF.
+// On Linux with raw TCP sockets, it attempts splice(2) for zero-copy transfer
+// before falling back to io.Copy.
+func BidirectionalCopy(client, upstream net.Conn) error {
+	var wg sync.WaitGroup
+	var clientErr, upstreamErr error
+
+	wg.Add(2)
+
+	// upstream → client
+	go func() {
+		defer wg.Done()
+		clientErr = copyOneDirection(client, upstream)
+		// When upstream closes or errors, half-close the client write side
+		// so the client knows there's no more data coming.
+		if tc, ok := client.(*net.TCPConn); ok {
+			tc.CloseWrite() //nolint:errcheck
+		}
+	}()
+
+	// client → upstream
+	go func() {
+		defer wg.Done()
+		upstreamErr = copyOneDirection(upstream, client)
+		// When client closes or errors, half-close the upstream write side.
+		if tc, ok := upstream.(*net.TCPConn); ok {
+			tc.CloseWrite() //nolint:errcheck
+		}
+	}()
+
+	wg.Wait()
+
+	// Return whichever error is more meaningful
+	if clientErr != nil {
+		return clientErr
+	}
+	return upstreamErr
+}
+
+// copyOneDirection copies from src to dst using the most efficient method
+// available on the current platform. On Linux with raw TCP sockets it tries
+// splice(2) first; otherwise it falls back to io.Copy.
+func copyOneDirection(dst, src net.Conn) error {
+	// Try platform-specific zero-copy (splice on Linux)
+	ok, err := trySplice(dst, src)
+	if ok {
+		return err
+	}
+
+	// Fallback: standard io.Copy (uses sendfile or splice via Go runtime
+	// when possible, otherwise userspace buffer copy)
+	buf := bufPool.Get().([]byte)
+	defer bufPool.Put(buf)
+	_, err = io.CopyBuffer(dst, src, buf)
+	return err
+}
+
+// bufPool reuses 32KB buffers for io.CopyBuffer to reduce GC pressure.
+var bufPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, 32*1024)
+		return buf
+	},
+}

--- a/core/internal/proxy/tunnel_test.go
+++ b/core/internal/proxy/tunnel_test.go
@@ -1,0 +1,201 @@
+package proxy
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"io"
+	"math/rand"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBidirectionalCopy_Basic(t *testing.T) {
+	// Create two pairs of connected TCP sockets to simulate client ↔ upstream.
+	clientConn, proxyClientSide := tcpPipe(t)
+	upstreamConn, proxyUpstreamSide := tcpPipe(t)
+
+	defer clientConn.Close()
+	defer upstreamConn.Close()
+
+	// Start bidirectional copy (proxy sits between proxyClientSide and proxyUpstreamSide).
+	done := make(chan error, 1)
+	go func() {
+		done <- BidirectionalCopy(proxyClientSide, proxyUpstreamSide)
+	}()
+
+	// Client sends data → should arrive at upstream.
+	clientMsg := []byte("hello from client")
+	if _, err := clientConn.Write(clientMsg); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+
+	buf := make([]byte, 256)
+	n, err := upstreamConn.Read(buf)
+	if err != nil {
+		t.Fatalf("upstream read: %v", err)
+	}
+	if !bytes.Equal(buf[:n], clientMsg) {
+		t.Fatalf("upstream got %q, want %q", buf[:n], clientMsg)
+	}
+
+	// Upstream sends data → should arrive at client.
+	upstreamMsg := []byte("hello from upstream")
+	if _, err := upstreamConn.Write(upstreamMsg); err != nil {
+		t.Fatalf("upstream write: %v", err)
+	}
+
+	n, err = clientConn.Read(buf)
+	if err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	if !bytes.Equal(buf[:n], upstreamMsg) {
+		t.Fatalf("client got %q, want %q", buf[:n], upstreamMsg)
+	}
+
+	// Close both ends and wait for BidirectionalCopy to finish.
+	clientConn.Close()
+	upstreamConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("BidirectionalCopy did not finish in time")
+	}
+}
+
+func TestBidirectionalCopy_LargePayload(t *testing.T) {
+	clientConn, proxyClientSide := tcpPipe(t)
+	upstreamConn, proxyUpstreamSide := tcpPipe(t)
+
+	defer clientConn.Close()
+	defer upstreamConn.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- BidirectionalCopy(proxyClientSide, proxyUpstreamSide)
+	}()
+
+	// Generate 10MB of random data.
+	const payloadSize = 10 * 1024 * 1024
+	payload := make([]byte, payloadSize)
+	rand.New(rand.NewSource(42)).Read(payload)
+	expectedHash := sha256.Sum256(payload)
+
+	// Write in background.
+	var writeErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, writeErr = clientConn.Write(payload)
+		clientConn.(*net.TCPConn).CloseWrite() //nolint:errcheck
+	}()
+
+	// Read all on the upstream side.
+	received, err := io.ReadAll(upstreamConn)
+	if err != nil {
+		t.Fatalf("upstream read: %v", err)
+	}
+
+	wg.Wait()
+	if writeErr != nil {
+		t.Fatalf("client write: %v", writeErr)
+	}
+
+	if len(received) != payloadSize {
+		t.Fatalf("received %d bytes, want %d", len(received), payloadSize)
+	}
+
+	gotHash := sha256.Sum256(received)
+	if gotHash != expectedHash {
+		t.Fatal("SHA256 mismatch: data corruption during transfer")
+	}
+
+	upstreamConn.Close()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("BidirectionalCopy did not finish in time")
+	}
+}
+
+func TestBidirectionalCopy_HalfClose(t *testing.T) {
+	clientConn, proxyClientSide := tcpPipe(t)
+	upstreamConn, proxyUpstreamSide := tcpPipe(t)
+
+	defer clientConn.Close()
+	defer upstreamConn.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- BidirectionalCopy(proxyClientSide, proxyUpstreamSide)
+	}()
+
+	// Client sends data then closes write side.
+	msg := []byte("one-way message")
+	clientConn.Write(msg)                       //nolint:errcheck
+	clientConn.(*net.TCPConn).CloseWrite()      //nolint:errcheck
+
+	// Upstream should receive the message and then get EOF.
+	buf := make([]byte, 256)
+	n, err := upstreamConn.Read(buf)
+	if err != nil {
+		t.Fatalf("upstream read: %v", err)
+	}
+	if !bytes.Equal(buf[:n], msg) {
+		t.Fatalf("got %q, want %q", buf[:n], msg)
+	}
+
+	// Upstream should see EOF on next read (half-close propagation).
+	upstreamConn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	_, err = upstreamConn.Read(buf)
+	if err != io.EOF {
+		t.Fatalf("expected EOF after half-close, got: %v", err)
+	}
+
+	// Close upstream too, BidirectionalCopy should finish.
+	upstreamConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("BidirectionalCopy did not finish after both sides closed")
+	}
+}
+
+// tcpPipe creates a connected pair of TCP sockets using a loopback listener.
+// Returns (external side, internal side). The internal side is what the proxy
+// would operate on.
+func tcpPipe(t *testing.T) (net.Conn, net.Conn) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	var serverConn net.Conn
+	var serverErr error
+	accepted := make(chan struct{})
+	go func() {
+		serverConn, serverErr = ln.Accept()
+		close(accepted)
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		ln.Close()
+		t.Fatalf("dial: %v", err)
+	}
+
+	<-accepted
+	ln.Close()
+	if serverErr != nil {
+		clientConn.Close()
+		t.Fatalf("accept: %v", serverErr)
+	}
+
+	return clientConn, serverConn
+}

--- a/core/internal/proxy/user_auth.go
+++ b/core/internal/proxy/user_auth.go
@@ -13,7 +13,6 @@ import (
 	"github.com/alpkeskin/rota/core/internal/models"
 	"github.com/alpkeskin/rota/core/internal/repository"
 	"github.com/alpkeskin/rota/core/pkg/logger"
-	"github.com/elazarl/goproxy"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -83,11 +82,11 @@ func NewUserAuthMiddleware(
 // HandleRequest is called for every HTTP proxy request.
 // It reads Proxy-Authorization, looks up the user, builds a PoolChain and stores
 // it in the request context so the handler can use it.
-func (m *UserAuthMiddleware) HandleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+func (m *UserAuthMiddleware) HandleRequest(req *http.Request) (*http.Request, *http.Response) {
 	username, password, ok := parseProxyAuth(req)
 	if !ok {
 		// No credentials provided — check legacy auth
-		return m.legacy.HandleRequest(req, ctx)
+		return m.legacy.HandleRequest(req)
 	}
 
 	chain, err := m.resolve(req.Context(), username, password)
@@ -96,7 +95,7 @@ func (m *UserAuthMiddleware) HandleRequest(req *http.Request, ctx *goproxy.Proxy
 		// If legacy auth is enabled and credentials don't match a proxy_user,
 		// still try the legacy path (single admin user)
 		if m.legacy != nil {
-			if _, resp := m.legacy.HandleRequest(req, ctx); resp != nil {
+			if _, resp := m.legacy.HandleRequest(req); resp != nil {
 				return req, resp
 			}
 			// legacy auth passed with these same credentials → allow without pool chain
@@ -113,8 +112,8 @@ func (m *UserAuthMiddleware) HandleRequest(req *http.Request, ctx *goproxy.Proxy
 }
 
 // HandleConnect is the same but for HTTPS CONNECT.
-func (m *UserAuthMiddleware) HandleConnect(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-	return m.HandleRequest(req, ctx)
+func (m *UserAuthMiddleware) HandleConnect(req *http.Request) (*http.Request, *http.Response) {
+	return m.HandleRequest(req)
 }
 
 // resolve authenticates the user and returns a warm PoolChain.

--- a/core/internal/repository/pool_repository.go
+++ b/core/internal/repository/pool_repository.go
@@ -227,7 +227,7 @@ func (r *PoolRepository) Delete(ctx context.Context, id int) error {
 func (r *PoolRepository) GetProxies(ctx context.Context, poolID int) ([]models.PoolProxy, error) {
 	query := `
 		SELECT
-			p.id, p.address, p.protocol, p.status,
+			p.id, p.address, p.protocol, p.username, p.password, p.status,
 			p.country_code, p.country_name, p.region_name, p.city_name, p.isp,
 			p.requests, p.successful_requests, p.failed_requests,
 			p.avg_response_time, p.last_check, ppm.added_at
@@ -247,7 +247,7 @@ func (r *PoolRepository) GetProxies(ctx context.Context, poolID int) ([]models.P
 		var pp models.PoolProxy
 		var succReq, failReq int64
 		err := rows.Scan(
-			&pp.ProxyID, &pp.Address, &pp.Protocol, &pp.Status,
+			&pp.ProxyID, &pp.Address, &pp.Protocol, &pp.Username, &pp.Password, &pp.Status,
 			&pp.CountryCode, &pp.CountryName, &pp.RegionName, &pp.CityName, &pp.ISP,
 			&pp.Requests, &succReq, &failReq,
 			&pp.AvgResponseTime, &pp.LastCheck, &pp.AddedAt,

--- a/core/internal/repository/pool_repository.go
+++ b/core/internal/repository/pool_repository.go
@@ -443,7 +443,7 @@ func (r *PoolRepository) SyncAllAutoSyncPools(ctx context.Context) (int, error) 
 	synced := 0
 	for _, pool := range pools {
 		if pool.AutoSync && pool.Enabled && pool.SyncMode != "manual" {
-			if _, err := r.SyncPoolByFilters(ctx, pool); err == nil {
+			if _, _, err := r.SyncPoolByFilters(ctx, pool); err == nil {
 				synced++
 			}
 		}
@@ -627,16 +627,18 @@ func (r *PoolRepository) SetTagFilters(ctx context.Context, poolID int, tags []s
 	return nil
 }
 
-// SyncPoolByFilters rebuilds pool membership using geo + ISP + tag filters combined
-func (r *PoolRepository) SyncPoolByFilters(ctx context.Context, pool models.ProxyPool) (int, error) {
+// SyncPoolByFilters rebuilds pool membership using geo + ISP + tag filters combined.
+// Returns (totalCount, newIDs, err) — newIDs are proxies that weren't in the pool
+// before this sync call, so callers can trigger health checks only for those.
+func (r *PoolRepository) SyncPoolByFilters(ctx context.Context, pool models.ProxyPool) (int, []int, error) {
 	// Skip sync if sync_mode is manual
 	if pool.SyncMode == "manual" {
-		return 0, nil
+		return 0, nil, nil
 	}
 
 	geoFilters, err := r.GetGeoFilters(ctx, pool.ID)
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	// Fall back to legacy single country/city
 	if len(geoFilters) == 0 && pool.CountryCode != nil && *pool.CountryCode != "" {
@@ -648,16 +650,16 @@ func (r *PoolRepository) SyncPoolByFilters(ctx context.Context, pool models.Prox
 
 	ispFilters, err := r.GetISPFilters(ctx, pool.ID)
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	tagFilters, err := r.GetTagFilters(ctx, pool.ID)
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 
 	// If no filters at all — nothing to sync
 	if len(geoFilters) == 0 && len(ispFilters) == 0 && len(tagFilters) == 0 {
-		return 0, nil
+		return 0, nil, nil
 	}
 
 	idSet := make(map[int]bool)
@@ -684,11 +686,11 @@ func (r *PoolRepository) SyncPoolByFilters(ctx context.Context, pool models.Prox
 		if f.CityName != "" {
 			if err := addIDs(`SELECT id FROM proxies WHERE country_code=$1 AND city_name ILIKE $2`,
 				f.CountryCode, "%"+f.CityName+"%"); err != nil {
-				return 0, err
+				return 0, nil, err
 			}
 		} else {
 			if err := addIDs(`SELECT id FROM proxies WHERE country_code=$1`, f.CountryCode); err != nil {
-				return 0, err
+				return 0, nil, err
 			}
 		}
 	}
@@ -696,7 +698,7 @@ func (r *PoolRepository) SyncPoolByFilters(ctx context.Context, pool models.Prox
 	// ISP filters (OR between ISPs, ILIKE match)
 	for _, isp := range ispFilters {
 		if err := addIDs(`SELECT id FROM proxies WHERE isp ILIKE $1`, "%"+isp+"%"); err != nil {
-			return 0, err
+			return 0, nil, err
 		}
 	}
 
@@ -705,30 +707,52 @@ func (r *PoolRepository) SyncPoolByFilters(ctx context.Context, pool models.Prox
 		rows, err := r.db.Pool.Query(ctx,
 			`SELECT id FROM proxies WHERE tags @> $1::text[]`, tagFilters)
 		if err != nil {
-			return 0, fmt.Errorf("tag filter query failed: %w", err)
+			return 0, nil, fmt.Errorf("tag filter query failed: %w", err)
 		}
 		defer rows.Close()
 		for rows.Next() {
 			var id int
 			if err := rows.Scan(&id); err != nil {
-				return 0, err
+				return 0, nil, err
 			}
 			idSet[id] = true
 		}
 	}
 
+	// Snapshot current pool membership BEFORE clearing so we can diff and
+	// report which proxies are newly added by this sync.
+	currentSet := make(map[int]bool)
+	curRows, err := r.db.Pool.Query(ctx,
+		`SELECT proxy_id FROM pool_proxies WHERE pool_id = $1`, pool.ID)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to snapshot pool membership: %w", err)
+	}
+	for curRows.Next() {
+		var id int
+		if err := curRows.Scan(&id); err != nil {
+			curRows.Close()
+			return 0, nil, err
+		}
+		currentSet[id] = true
+	}
+	curRows.Close()
+
 	ids := make([]int, 0, len(idSet))
+	newIDs := make([]int, 0)
 	for id := range idSet {
 		ids = append(ids, id)
+		if !currentSet[id] {
+			newIDs = append(newIDs, id)
+		}
 	}
 
 	if err := r.ClearProxies(ctx, pool.ID); err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	if err := r.AddProxies(ctx, pool.ID, ids); err != nil {
-		return 0, err
+		return 0, nil, err
 	}
-	return len(ids), nil
+	return len(ids), newIDs, nil
 }
 
 // --- Alert Rules ---

--- a/core/internal/repository/source_repository.go
+++ b/core/internal/repository/source_repository.go
@@ -20,14 +20,31 @@ func NewSourceRepository(db *database.DB) *SourceRepository {
 	return &SourceRepository{db: db}
 }
 
+// columns returned by every SELECT — keep in lock-step with scanSource().
+const sourceColumns = `
+	id, name, url, protocol, enabled, interval_minutes,
+	last_fetched_at, last_count, last_total, last_error,
+	cleanup_enabled, cleanup_days,
+	created_at, updated_at
+`
+
+// scanSource scans a single row into ProxySource. row can be pgx.Row or pgx.Rows.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanSource(r rowScanner, s *models.ProxySource) error {
+	return r.Scan(
+		&s.ID, &s.Name, &s.URL, &s.Protocol, &s.Enabled,
+		&s.IntervalMinutes, &s.LastFetchedAt, &s.LastCount, &s.LastTotal, &s.LastError,
+		&s.CleanupEnabled, &s.CleanupDays,
+		&s.CreatedAt, &s.UpdatedAt,
+	)
+}
+
 // List returns all proxy sources
 func (r *SourceRepository) List(ctx context.Context) ([]models.ProxySource, error) {
-	query := `
-		SELECT id, name, url, protocol, enabled, interval_minutes,
-		       last_fetched_at, last_count, last_error, created_at, updated_at
-		FROM proxy_sources
-		ORDER BY created_at DESC
-	`
+	query := `SELECT ` + sourceColumns + ` FROM proxy_sources ORDER BY created_at DESC`
 	rows, err := r.db.Pool.Query(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list sources: %w", err)
@@ -37,12 +54,7 @@ func (r *SourceRepository) List(ctx context.Context) ([]models.ProxySource, erro
 	var sources []models.ProxySource
 	for rows.Next() {
 		var s models.ProxySource
-		err := rows.Scan(
-			&s.ID, &s.Name, &s.URL, &s.Protocol, &s.Enabled,
-			&s.IntervalMinutes, &s.LastFetchedAt, &s.LastCount, &s.LastError,
-			&s.CreatedAt, &s.UpdatedAt,
-		)
-		if err != nil {
+		if err := scanSource(rows, &s); err != nil {
 			return nil, fmt.Errorf("failed to scan source: %w", err)
 		}
 		sources = append(sources, s)
@@ -55,17 +67,9 @@ func (r *SourceRepository) List(ctx context.Context) ([]models.ProxySource, erro
 
 // GetByID returns a source by ID
 func (r *SourceRepository) GetByID(ctx context.Context, id int) (*models.ProxySource, error) {
-	query := `
-		SELECT id, name, url, protocol, enabled, interval_minutes,
-		       last_fetched_at, last_count, last_error, created_at, updated_at
-		FROM proxy_sources WHERE id = $1
-	`
+	query := `SELECT ` + sourceColumns + ` FROM proxy_sources WHERE id = $1`
 	var s models.ProxySource
-	err := r.db.Pool.QueryRow(ctx, query, id).Scan(
-		&s.ID, &s.Name, &s.URL, &s.Protocol, &s.Enabled,
-		&s.IntervalMinutes, &s.LastFetchedAt, &s.LastCount, &s.LastError,
-		&s.CreatedAt, &s.UpdatedAt,
-	)
+	err := scanSource(r.db.Pool.QueryRow(ctx, query, id), &s)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}
@@ -77,27 +81,30 @@ func (r *SourceRepository) GetByID(ctx context.Context, id int) (*models.ProxySo
 
 // Create inserts a new source
 func (r *SourceRepository) Create(ctx context.Context, req models.CreateProxySourceRequest) (*models.ProxySource, error) {
+	// Default cleanup_days to 7 if cleanup is enabled but days not provided
+	cleanupDays := req.CleanupDays
+	if cleanupDays <= 0 {
+		cleanupDays = 7
+	}
 	query := `
-		INSERT INTO proxy_sources (name, url, protocol, enabled, interval_minutes)
-		VALUES ($1, $2, $3, $4, $5)
-		RETURNING id, name, url, protocol, enabled, interval_minutes,
-		          last_fetched_at, last_count, last_error, created_at, updated_at
-	`
+		INSERT INTO proxy_sources (
+			name, url, protocol, enabled, interval_minutes,
+			cleanup_enabled, cleanup_days
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING ` + sourceColumns
 	var s models.ProxySource
-	err := r.db.Pool.QueryRow(ctx, query,
+	err := scanSource(r.db.Pool.QueryRow(ctx, query,
 		req.Name, req.URL, req.Protocol, req.Enabled, req.IntervalMinutes,
-	).Scan(
-		&s.ID, &s.Name, &s.URL, &s.Protocol, &s.Enabled,
-		&s.IntervalMinutes, &s.LastFetchedAt, &s.LastCount, &s.LastError,
-		&s.CreatedAt, &s.UpdatedAt,
-	)
+		req.CleanupEnabled, cleanupDays,
+	), &s)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create source: %w", err)
 	}
 	return &s, nil
 }
 
-// Update modifies an existing source
+// Update modifies an existing source. Empty/zero fields are left unchanged.
 func (r *SourceRepository) Update(ctx context.Context, id int, req models.UpdateProxySourceRequest) (*models.ProxySource, error) {
 	query := `
 		UPDATE proxy_sources SET
@@ -106,19 +113,16 @@ func (r *SourceRepository) Update(ctx context.Context, id int, req models.Update
 			protocol         = CASE WHEN $3 <> '' THEN $3 ELSE protocol END,
 			enabled          = COALESCE($4, enabled),
 			interval_minutes = CASE WHEN $5 > 0 THEN $5 ELSE interval_minutes END,
+			cleanup_enabled  = COALESCE($6, cleanup_enabled),
+			cleanup_days     = CASE WHEN $7 > 0 THEN $7 ELSE cleanup_days END,
 			updated_at       = NOW()
-		WHERE id = $6
-		RETURNING id, name, url, protocol, enabled, interval_minutes,
-		          last_fetched_at, last_count, last_error, created_at, updated_at
-	`
+		WHERE id = $8
+		RETURNING ` + sourceColumns
 	var s models.ProxySource
-	err := r.db.Pool.QueryRow(ctx, query,
-		req.Name, req.URL, req.Protocol, req.Enabled, req.IntervalMinutes, id,
-	).Scan(
-		&s.ID, &s.Name, &s.URL, &s.Protocol, &s.Enabled,
-		&s.IntervalMinutes, &s.LastFetchedAt, &s.LastCount, &s.LastError,
-		&s.CreatedAt, &s.UpdatedAt,
-	)
+	err := scanSource(r.db.Pool.QueryRow(ctx, query,
+		req.Name, req.URL, req.Protocol, req.Enabled, req.IntervalMinutes,
+		req.CleanupEnabled, req.CleanupDays, id,
+	), &s)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}
@@ -134,8 +138,9 @@ func (r *SourceRepository) Delete(ctx context.Context, id int) error {
 	return err
 }
 
-// UpdateFetchResult records the outcome of a fetch run
-func (r *SourceRepository) UpdateFetchResult(ctx context.Context, id int, count int, fetchErr error) error {
+// UpdateFetchResult records the outcome of a fetch run.
+// imported = newly created on this fetch; total = total parseable lines returned.
+func (r *SourceRepository) UpdateFetchResult(ctx context.Context, id int, imported int, total int, fetchErr error) error {
 	var errMsg *string
 	if fetchErr != nil {
 		s := fetchErr.Error()
@@ -144,17 +149,53 @@ func (r *SourceRepository) UpdateFetchResult(ctx context.Context, id int, count 
 	now := time.Now()
 	_, err := r.db.Pool.Exec(ctx, `
 		UPDATE proxy_sources
-		SET last_fetched_at = $1, last_count = $2, last_error = $3, updated_at = NOW()
-		WHERE id = $4
-	`, now, count, errMsg, id)
+		SET last_fetched_at = $1,
+		    last_count      = $2,
+		    last_total      = $3,
+		    last_error      = $4,
+		    updated_at      = NOW()
+		WHERE id = $5
+	`, now, imported, total, errMsg, id)
 	return err
+}
+
+// MarkSeen updates last_seen_at=NOW() for all proxies belonging to sourceID
+// whose address is in the given list. Called after every successful fetch.
+func (r *SourceRepository) MarkSeen(ctx context.Context, sourceID int, addresses []string) error {
+	if len(addresses) == 0 {
+		return nil
+	}
+	_, err := r.db.Pool.Exec(ctx, `
+		UPDATE proxies
+		SET last_seen_at = NOW()
+		WHERE source_id = $1
+		  AND address = ANY($2::text[])
+	`, sourceID, addresses)
+	return err
+}
+
+// DeleteStaleForSource hard-deletes proxies belonging to sourceID whose
+// last_seen_at is older than maxAgeDays days. Returns the number deleted.
+func (r *SourceRepository) DeleteStaleForSource(ctx context.Context, sourceID int, maxAgeDays int) (int, error) {
+	if maxAgeDays <= 0 {
+		return 0, nil
+	}
+	tag, err := r.db.Pool.Exec(ctx, `
+		DELETE FROM proxies
+		WHERE source_id = $1
+		  AND last_seen_at IS NOT NULL
+		  AND last_seen_at < NOW() - make_interval(days => $2)
+	`, sourceID, maxAgeDays)
+	if err != nil {
+		return 0, err
+	}
+	return int(tag.RowsAffected()), nil
 }
 
 // GetDueForFetch returns sources that are enabled and overdue for refresh
 func (r *SourceRepository) GetDueForFetch(ctx context.Context) ([]models.ProxySource, error) {
 	query := `
-		SELECT id, name, url, protocol, enabled, interval_minutes,
-		       last_fetched_at, last_count, last_error, created_at, updated_at
+		SELECT ` + sourceColumns + `
 		FROM proxy_sources
 		WHERE enabled = true
 		  AND (last_fetched_at IS NULL
@@ -170,11 +211,7 @@ func (r *SourceRepository) GetDueForFetch(ctx context.Context) ([]models.ProxySo
 	var sources []models.ProxySource
 	for rows.Next() {
 		var s models.ProxySource
-		if err := rows.Scan(
-			&s.ID, &s.Name, &s.URL, &s.Protocol, &s.Enabled,
-			&s.IntervalMinutes, &s.LastFetchedAt, &s.LastCount, &s.LastError,
-			&s.CreatedAt, &s.UpdatedAt,
-		); err != nil {
+		if err := scanSource(rows, &s); err != nil {
 			return nil, err
 		}
 		sources = append(sources, s)

--- a/core/internal/services/pool_service.go
+++ b/core/internal/services/pool_service.go
@@ -90,20 +90,94 @@ func (ps *PoolService) runAutoSync(ctx context.Context) {
 	}
 	for _, pool := range pools {
 		if pool.AutoSync && pool.Enabled && pool.SyncMode != "manual" {
-			if _, err := ps.poolRepo.SyncPoolByFilters(ctx, pool); err != nil {
-				ps.logger.Warn("auto-sync pool failed", "pool_id", pool.ID, "error", err)
+			poolCopy := pool
+			total, newIDs, err := ps.poolRepo.SyncPoolByFilters(ctx, poolCopy)
+			if err != nil {
+				ps.logger.Warn("auto-sync pool failed", "pool_id", poolCopy.ID, "error", err)
+				continue
+			}
+			// If new proxies joined the pool during this sync, test them
+			// immediately instead of waiting up to ~30min for the next scheduled
+			// pool health check. Without this, a newly-bought proxy that lands
+			// in a pool stays 'idle' for half an hour.
+			if len(newIDs) > 0 {
+				ps.logger.Info("auto-sync added new proxies to pool",
+					"pool_id", poolCopy.ID, "added", len(newIDs), "total", total)
+				newCopy := append([]int(nil), newIDs...)
+				go func(p models.ProxyPool, ids []int) {
+					hcCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+					defer cancel()
+					if err := ps.checkProxiesByIDs(hcCtx, p.HealthCheckURL, ids, 20); err != nil {
+						ps.logger.Warn("auto-HC on new pool members failed",
+							"pool_id", p.ID, "error", err)
+					}
+				}(poolCopy, newCopy)
 			}
 		}
 	}
 }
 
-// SyncPool re-builds the membership of a single pool from all its filters (geo+isp+tag)
+// SyncPool re-builds the membership of a single pool from all its filters (geo+isp+tag).
+// Returns total pool size after sync. New members are NOT auto-health-checked from
+// this path — the public API caller should trigger a pool HC explicitly if desired.
 func (ps *PoolService) SyncPool(ctx context.Context, poolID int) (int, error) {
 	pool, err := ps.poolRepo.GetByID(ctx, poolID)
 	if err != nil || pool == nil {
 		return 0, fmt.Errorf("pool not found")
 	}
-	return ps.poolRepo.SyncPoolByFilters(ctx, *pool)
+	total, _, err := ps.poolRepo.SyncPoolByFilters(ctx, *pool)
+	return total, err
+}
+
+// checkProxiesByIDs runs a health check on the specified proxy IDs only.
+// Used by auto-sync to test newly-added pool members immediately instead of
+// waiting for the next scheduled */30 cron tick.
+func (ps *PoolService) checkProxiesByIDs(ctx context.Context, checkURL string, proxyIDs []int, workers int) error {
+	if len(proxyIDs) == 0 {
+		return nil
+	}
+	if workers <= 0 {
+		workers = 20
+	}
+	if checkURL == "" {
+		checkURL = "https://api.ipify.org"
+	}
+
+	// Load the proxy rows for the given IDs
+	rows, err := ps.proxyRepo.GetDB().Pool.Query(ctx, `
+		SELECT id, address, protocol, username, password, status
+		FROM proxies
+		WHERE id = ANY($1::int[])
+	`, proxyIDs)
+	if err != nil {
+		return fmt.Errorf("failed to load proxies by ids: %w", err)
+	}
+	defer rows.Close()
+
+	var proxies []*models.Proxy
+	for rows.Next() {
+		var p models.Proxy
+		if err := rows.Scan(&p.ID, &p.Address, &p.Protocol, &p.Username, &p.Password, &p.Status); err != nil {
+			return err
+		}
+		proxies = append(proxies, &p)
+	}
+	if len(proxies) == 0 {
+		return nil
+	}
+
+	wp := workerpool.New(workers)
+	for _, p := range proxies {
+		p := p
+		wp.Submit(func() {
+			ps.checkOneProxy(ctx, p, checkURL)
+		})
+	}
+	wp.StopWait()
+
+	ps.logger.Info("auto-HC on new pool members completed",
+		"count", len(proxies), "url", checkURL)
+	return nil
 }
 
 // HealthCheckPool tests all proxies in a pool against the pool's custom URL

--- a/core/internal/services/pool_service.go
+++ b/core/internal/services/pool_service.go
@@ -2,8 +2,6 @@ package services
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"net/http"
 	"strings"
@@ -11,6 +9,7 @@ import (
 	"time"
 
 	"github.com/alpkeskin/rota/core/internal/models"
+	"github.com/alpkeskin/rota/core/internal/proxy"
 	"github.com/alpkeskin/rota/core/internal/repository"
 	"github.com/alpkeskin/rota/core/pkg/logger"
 	"github.com/gammazero/workerpool"
@@ -138,7 +137,7 @@ func (ps *PoolService) HealthCheckPool(ctx context.Context, poolID int, checkURL
 		i := i
 		pp := pp
 		wp.Submit(func() {
-			res := ps.checkOneProxy(ctx, pp.ProxyID, pp.Address, pp.Protocol, url)
+			res := ps.checkOneProxy(ctx, pp.ToProxy(), url)
 			slots[i].result = res
 		})
 	}
@@ -168,24 +167,24 @@ func (ps *PoolService) HealthCheckPool(ctx context.Context, poolID int, checkURL
 
 // checkOneProxy performs a single proxy health check against the given URL.
 // Uses a 10 second timeout (enough for alive proxies, fast fail for dead ones).
-func (ps *PoolService) checkOneProxy(ctx context.Context, proxyID int, address, protocol, targetURL string) models.ProxyTestResult {
-	return ps.checkOneProxyTimeout(ctx, proxyID, address, protocol, targetURL, 10*time.Second)
+func (ps *PoolService) checkOneProxy(ctx context.Context, p *models.Proxy, targetURL string) models.ProxyTestResult {
+	return ps.checkOneProxyTimeout(ctx, p, targetURL, 10*time.Second)
 }
 
-func (ps *PoolService) checkOneProxyTimeout(ctx context.Context, proxyID int, address, protocol, targetURL string, timeout time.Duration) models.ProxyTestResult {
+func (ps *PoolService) checkOneProxyTimeout(ctx context.Context, p *models.Proxy, targetURL string, timeout time.Duration) models.ProxyTestResult {
 	start := time.Now()
 	result := models.ProxyTestResult{
-		ID:       proxyID,
-		Address:  address,
+		ID:       p.ID,
+		Address:  p.Address,
 		TestedAt: start,
 	}
 
-	transport, err := buildTransport(address, protocol)
+	transport, err := proxy.CreateProxyTransport(p)
 	if err != nil {
 		result.Status = "failed"
 		msg := err.Error()
 		result.Error = &msg
-		ps.updateProxyStatus(ctx, proxyID, "failed")
+		ps.updateProxyStatus(ctx, p.ID, "failed")
 		return result
 	}
 
@@ -205,7 +204,7 @@ func (ps *PoolService) checkOneProxyTimeout(ctx context.Context, proxyID int, ad
 		result.Status = "failed"
 		msg := err.Error()
 		result.Error = &msg
-		ps.updateProxyStatus(ctx, proxyID, "failed")
+		ps.updateProxyStatus(ctx, p.ID, "failed")
 		return result
 	}
 	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; Rota/1.0)")
@@ -216,7 +215,7 @@ func (ps *PoolService) checkOneProxyTimeout(ctx context.Context, proxyID int, ad
 		result.Status = "failed"
 		msg := err.Error()
 		result.Error = &msg
-		ps.updateProxyStatus(ctx, proxyID, "failed")
+		ps.updateProxyStatus(ctx, p.ID, "failed")
 		return result
 	}
 	defer resp.Body.Close()
@@ -224,12 +223,12 @@ func (ps *PoolService) checkOneProxyTimeout(ctx context.Context, proxyID int, ad
 	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
 		result.Status = "active"
 		result.ResponseTime = &dur
-		ps.updateProxyStatus(ctx, proxyID, "active")
+		ps.updateProxyStatus(ctx, p.ID, "active")
 	} else {
 		result.Status = "failed"
 		msg := fmt.Sprintf("HTTP %d", resp.StatusCode)
 		result.Error = &msg
-		ps.updateProxyStatus(ctx, proxyID, "failed")
+		ps.updateProxyStatus(ctx, p.ID, "failed")
 	}
 	return result
 }
@@ -239,43 +238,6 @@ func (ps *PoolService) updateProxyStatus(ctx context.Context, proxyID int, statu
 	ps.proxyRepo.GetDB().Pool.Exec(ctx,
 		`UPDATE proxies SET status = $1, last_check = NOW(), updated_at = NOW() WHERE id = $2`,
 		status, proxyID)
-}
-
-// buildTransport creates an http.Transport routed through the given proxy
-func buildTransport(address, protocol string) (*http.Transport, error) {
-	proxyURL := fmt.Sprintf("%s://%s", protocol, address)
-	switch strings.ToLower(protocol) {
-	case "http", "https":
-		parsed, err := parseURL(proxyURL)
-		if err != nil {
-			return nil, err
-		}
-		return &http.Transport{
-			Proxy:           http.ProxyURL(parsed),
-			TLSClientConfig: permissiveTLS(),
-		}, nil
-	case "socks5", "socks4", "socks4a":
-		// Use golang.org/x/net/proxy or h12.io/socks
-		dialer, err := buildSocksDialer(address, protocol)
-		if err != nil {
-			return nil, err
-		}
-		return &http.Transport{
-			DialContext:     dialer,
-			TLSClientConfig: permissiveTLS(),
-		}, nil
-	default:
-		return nil, fmt.Errorf("unsupported protocol: %s", protocol)
-	}
-}
-
-func permissiveTLS() *tls.Config {
-	return &tls.Config{
-		InsecureSkipVerify: true,
-		VerifyPeerCertificate: func(_ [][]byte, _ [][]*x509.Certificate) error {
-			return nil
-		},
-	}
 }
 
 // HealthCheckPoolWithProgress is like HealthCheckPool but calls progressFn after each proxy finishes.
@@ -315,7 +277,7 @@ func (ps *PoolService) HealthCheckPoolWithProgress(
 	for i, pp := range proxies {
 		i, pp := i, pp
 		wp.Submit(func() {
-			res := ps.checkOneProxyTimeout(ctx, pp.ProxyID, pp.Address, pp.Protocol, url, 10*time.Second)
+			res := ps.checkOneProxyTimeout(ctx, pp.ToProxy(), url, 10*time.Second)
 			slots[i] = res
 
 			mu.Lock()

--- a/core/internal/services/pool_service.go
+++ b/core/internal/services/pool_service.go
@@ -118,15 +118,32 @@ func (ps *PoolService) runAutoSync(ctx context.Context) {
 }
 
 // SyncPool re-builds the membership of a single pool from all its filters (geo+isp+tag).
-// Returns total pool size after sync. New members are NOT auto-health-checked from
-// this path — the public API caller should trigger a pool HC explicitly if desired.
+// Returns total pool size after sync. Newly-added members get an immediate
+// scoped health check in the background so they're not left as `idle` when
+// the user expands the pool (e.g. adds a new country filter).
 func (ps *PoolService) SyncPool(ctx context.Context, poolID int) (int, error) {
 	pool, err := ps.poolRepo.GetByID(ctx, poolID)
 	if err != nil || pool == nil {
 		return 0, fmt.Errorf("pool not found")
 	}
-	total, _, err := ps.poolRepo.SyncPoolByFilters(ctx, *pool)
-	return total, err
+	total, newIDs, err := ps.poolRepo.SyncPoolByFilters(ctx, *pool)
+	if err != nil {
+		return total, err
+	}
+	if len(newIDs) > 0 {
+		ps.logger.Info("manual sync added new proxies to pool",
+			"pool_id", poolID, "added", len(newIDs), "total", total)
+		newCopy := append([]int(nil), newIDs...)
+		go func(p models.ProxyPool, ids []int) {
+			hcCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+			defer cancel()
+			if err := ps.checkProxiesByIDs(hcCtx, p.HealthCheckURL, ids, 20); err != nil {
+				ps.logger.Warn("auto-HC on new pool members failed (manual sync)",
+					"pool_id", p.ID, "error", err)
+			}
+		}(*pool, newCopy)
+	}
+	return total, nil
 }
 
 // checkProxiesByIDs runs a health check on the specified proxy IDs only.

--- a/core/internal/services/source_service.go
+++ b/core/internal/services/source_service.go
@@ -152,13 +152,13 @@ func (s *SourceService) FetchNow(ctx context.Context, sourceID int) (*models.Pro
 	if err != nil || src == nil {
 		return nil, 0, fmt.Errorf("source not found: %w", err)
 	}
-	count, fetchErr := s.fetchAndImport(ctx, src)
-	_ = s.sourceRepo.UpdateFetchResult(ctx, src.ID, count, fetchErr)
+	imported, total, fetchErr := s.fetchAndImport(ctx, src)
+	_ = s.sourceRepo.UpdateFetchResult(ctx, src.ID, imported, total, fetchErr)
 	if fetchErr != nil {
 		return src, 0, fetchErr
 	}
 	updated, _ := s.sourceRepo.GetByID(ctx, src.ID)
-	return updated, count, nil
+	return updated, imported, nil
 }
 
 // fetchDueSources finds all sources that are overdue and fetches them.
@@ -173,14 +173,16 @@ func (s *SourceService) fetchDueSources(ctx context.Context) {
 	}
 	for _, src := range sources {
 		srcCopy := src
-		count, fetchErr := s.fetchAndImport(ctx, &srcCopy)
-		if updateErr := s.sourceRepo.UpdateFetchResult(ctx, src.ID, count, fetchErr); updateErr != nil {
+		imported, total, fetchErr := s.fetchAndImport(ctx, &srcCopy)
+		if updateErr := s.sourceRepo.UpdateFetchResult(ctx, src.ID, imported, total, fetchErr); updateErr != nil {
 			s.logger.Error("failed to update source fetch result", "source_id", src.ID, "error", updateErr)
 		}
 		if fetchErr != nil {
 			s.logger.Error("failed to fetch source", "source_id", src.ID, "url", src.URL, "error", fetchErr)
 		} else {
-			s.logger.Info("fetched source", "source_id", src.ID, "name", src.Name, "count", count)
+			s.logger.Info("fetched source",
+				"source_id", src.ID, "name", src.Name,
+				"imported", imported, "total", total)
 		}
 	}
 
@@ -199,34 +201,38 @@ func (s *SourceService) syncAllPools(ctx context.Context) {
 }
 
 // fetchAndImport downloads the list, parses it, and upserts proxies.
-func (s *SourceService) fetchAndImport(ctx context.Context, src *models.ProxySource) (int, error) {
+// Returns (imported, total, err):
+//   - imported = number of NEW proxies created this fetch
+//   - total    = total number of parseable proxy lines returned by the source
+func (s *SourceService) fetchAndImport(ctx context.Context, src *models.ProxySource) (int, int, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, src.URL, nil)
 	if err != nil {
-		return 0, fmt.Errorf("failed to build request: %w", err)
+		return 0, 0, fmt.Errorf("failed to build request: %w", err)
 	}
 	req.Header.Set("User-Agent", "Rota-SourceFetcher/1.0")
 
 	resp, err := s.client.Do(req)
 	if err != nil {
-		return 0, fmt.Errorf("fetch failed: %w", err)
+		return 0, 0, fmt.Errorf("fetch failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("unexpected HTTP %d from %s", resp.StatusCode, src.URL)
+		return 0, 0, fmt.Errorf("unexpected HTTP %d from %s", resp.StatusCode, src.URL)
 	}
 
 	parsed, err := parseProxyList(resp.Body)
 	if err != nil {
-		return 0, fmt.Errorf("parse failed: %w", err)
+		return 0, 0, fmt.Errorf("parse failed: %w", err)
 	}
-	if len(parsed) == 0 {
-		return 0, nil
+	total := len(parsed)
+	if total == 0 {
+		return 0, 0, nil
 	}
 
 	// Build upsert requests — protocol from line takes priority over source default
-	requests := make([]models.CreateProxyRequest, 0, len(parsed))
-	addresses := make([]string, 0, len(parsed))
+	requests := make([]models.CreateProxyRequest, 0, total)
+	addresses := make([]string, 0, total)
 	for _, p := range parsed {
 		proto := src.Protocol
 		if p.protocol != "" {
@@ -244,31 +250,28 @@ func (s *SourceService) fetchAndImport(ctx context.Context, src *models.ProxySou
 
 	created, _ := s.bulkUpsert(ctx, requests)
 
+	// Stamp every address present in this fetch as "last seen now" so the
+	// soft-cleanup cron knows they're still live.
+	if err := s.sourceRepo.MarkSeen(ctx, src.ID, addresses); err != nil {
+		s.logger.Warn("failed to mark proxies as seen", "source_id", src.ID, "error", err)
+	}
+
+	// Per-source soft cleanup: delete proxies that have been absent from this
+	// source's fetch output for longer than cleanup_days.
+	if src.CleanupEnabled && src.CleanupDays > 0 {
+		deleted, err := s.sourceRepo.DeleteStaleForSource(ctx, src.ID, src.CleanupDays)
+		if err != nil {
+			s.logger.Warn("source cleanup failed", "source_id", src.ID, "error", err)
+		} else if deleted > 0 {
+			s.logger.Info("source cleanup removed stale proxies",
+				"source_id", src.ID, "deleted", deleted, "threshold_days", src.CleanupDays)
+		}
+	}
+
 	// Enrich geo data in the background
 	go s.enrichGeo(context.Background(), addresses)
 
-	// Auto health-check all idle/new proxies after import
-	if s.tester != nil && created > 0 {
-		go func() {
-			hcCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			defer cancel()
-			results, err := s.tester.CheckAllProxies(hcCtx)
-			if err != nil {
-				s.logger.Error("auto health-check after import failed", "error", err)
-			} else {
-				active := 0
-				for _, r := range results {
-					if r.Status == "active" {
-						active++
-					}
-				}
-				s.logger.Info("auto health-check after import completed",
-					"total", len(results), "active", active)
-			}
-		}()
-	}
-
-	return created, nil
+	return created, total, nil
 }
 
 // bulkUpsert upserts proxies. Returns (created, failed).

--- a/core/internal/services/source_service.go
+++ b/core/internal/services/source_service.go
@@ -85,12 +85,18 @@ func parseProxyLine(line string) (parsedProxy, bool) {
 	return parsedProxy{}, false
 }
 
+// ProxyTester is the subset of HealthChecker used by SourceService.
+type ProxyTester interface {
+	CheckAllProxies(ctx context.Context) ([]models.ProxyTestResult, error)
+}
+
 // SourceService fetches proxy lists from remote URLs and imports them into the DB.
 type SourceService struct {
 	sourceRepo *repository.SourceRepository
 	proxyRepo  *repository.ProxyRepository
 	poolRepo   *repository.PoolRepository
 	geoSvc     *GeoIPService
+	tester     ProxyTester // optional: auto health-check after import
 	logger     *logger.Logger
 	client     *http.Client
 
@@ -115,6 +121,11 @@ func NewSourceService(
 		client:     &http.Client{Timeout: 30 * time.Second},
 		stopCh:     make(chan struct{}),
 	}
+}
+
+// SetHealthChecker sets the proxy tester for auto health checks after import.
+func (s *SourceService) SetHealthChecker(t ProxyTester) {
+	s.tester = t
 }
 
 // Start runs a background goroutine that checks for due sources every minute.
@@ -235,6 +246,27 @@ func (s *SourceService) fetchAndImport(ctx context.Context, src *models.ProxySou
 
 	// Enrich geo data in the background
 	go s.enrichGeo(context.Background(), addresses)
+
+	// Auto health-check all idle/new proxies after import
+	if s.tester != nil && created > 0 {
+		go func() {
+			hcCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+			results, err := s.tester.CheckAllProxies(hcCtx)
+			if err != nil {
+				s.logger.Error("auto health-check after import failed", "error", err)
+			} else {
+				active := 0
+				for _, r := range results {
+					if r.Status == "active" {
+						active++
+					}
+				}
+				s.logger.Info("auto health-check after import completed",
+					"total", len(results), "active", active)
+			}
+		}()
+	}
 
 	return created, nil
 }

--- a/dashboard/app/dashboard/pools/page.tsx
+++ b/dashboard/app/dashboard/pools/page.tsx
@@ -90,6 +90,10 @@ export default function PoolsPage() {
   const [form, setForm] = useState<CreatePoolRequest>(DEFAULT_POOL_FORM)
   const [saving, setSaving] = useState(false)
 
+  // Quick-add geo filter inside edit dialog
+  const [newGeoCountry, setNewGeoCountry] = useState("")
+  const [newGeoCity, setNewGeoCity] = useState("")
+
   // Alert rules
   const [alertRules, setAlertRules] = useState<PoolAlertRule[]>([])
   const [alertDialogOpen, setAlertDialogOpen] = useState(false)
@@ -119,7 +123,9 @@ export default function PoolsPage() {
 
   const openCreate = () => {
     setEditPool(null)
-    setForm(DEFAULT_POOL_FORM)
+    setForm({ ...DEFAULT_POOL_FORM, geo_filters: [] })
+    setNewGeoCountry("")
+    setNewGeoCity("")
     setDialogOpen(true)
   }
 
@@ -143,6 +149,8 @@ export default function PoolsPage() {
       isp_filters: p.isp_filters ?? [],
       tag_filters: p.tag_filters ?? [],
     })
+    setNewGeoCountry("")
+    setNewGeoCity("")
     setDialogOpen(true)
   }
 
@@ -695,30 +703,134 @@ export default function PoolsPage() {
                 />
               </div>
 
-              <div className="flex flex-col gap-1.5">
-                <Label>Country code (filter)</Label>
-                <Input
-                  placeholder="US"
-                  maxLength={3}
-                  value={form.country_code ?? ""}
-                  onChange={e => setForm({ ...form, country_code: e.target.value || undefined })}
-                />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label>Region (filter)</Label>
-                <Input
-                  placeholder="California"
-                  value={form.region_name ?? ""}
-                  onChange={e => setForm({ ...form, region_name: e.target.value || undefined })}
-                />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label>City (filter)</Label>
-                <Input
-                  placeholder="Los Angeles"
-                  value={form.city_name ?? ""}
-                  onChange={e => setForm({ ...form, city_name: e.target.value || undefined })}
-                />
+              {/* Multi-country geo filters — lets a pool match proxies from multiple countries */}
+              <div className="col-span-2 flex flex-col gap-2 border rounded-md p-3">
+                <div className="flex items-center justify-between">
+                  <Label className="text-sm font-medium">Countries in this pool</Label>
+                  <span className="text-xs text-muted-foreground">
+                    {form.geo_filters?.length ?? 0} filter{(form.geo_filters?.length ?? 0) === 1 ? "" : "s"}
+                  </span>
+                </div>
+
+                {/* Existing filters as removable badges */}
+                <div className="flex flex-wrap gap-1.5 min-h-[28px]">
+                  {(form.geo_filters ?? []).length === 0 && (
+                    <span className="text-xs text-muted-foreground italic">
+                      No country filters yet — this pool will not sync any proxies. Add at least one below.
+                    </span>
+                  )}
+                  {(form.geo_filters ?? []).map((f, idx) => (
+                    <Badge key={`${f.country_code}-${f.city_name ?? ""}-${idx}`} variant="secondary" className="gap-1 pr-1">
+                      <img src={FLAG_CDN(f.country_code)} alt={f.country_code} className="h-3" />
+                      <span className="font-mono text-xs">{f.country_code.toUpperCase()}</span>
+                      {f.city_name && <span className="text-xs text-muted-foreground">/ {f.city_name}</span>}
+                      <button
+                        type="button"
+                        className="ml-0.5 rounded hover:bg-muted-foreground/20 px-1 text-xs leading-none"
+                        onClick={() => setForm({
+                          ...form,
+                          geo_filters: (form.geo_filters ?? []).filter((_, i) => i !== idx),
+                        })}
+                        title="Remove"
+                      >
+                        ×
+                      </button>
+                    </Badge>
+                  ))}
+                </div>
+
+                {/* Quick-add row: country code + optional city + Add button */}
+                <div className="flex gap-2 items-end pt-1">
+                  <div className="flex flex-col gap-1 flex-1">
+                    <Label htmlFor="new-geo-cc" className="text-xs">Country</Label>
+                    <Input
+                      id="new-geo-cc"
+                      placeholder="BR"
+                      maxLength={3}
+                      value={newGeoCountry}
+                      onChange={e => setNewGeoCountry(e.target.value.toUpperCase())}
+                      onKeyDown={e => {
+                        if (e.key === "Enter") {
+                          e.preventDefault()
+                          const cc = newGeoCountry.trim().toUpperCase()
+                          if (!cc) return
+                          const existing = form.geo_filters ?? []
+                          if (existing.some(f => f.country_code === cc && (f.city_name ?? "") === newGeoCity.trim())) {
+                            toast.error("Already added")
+                            return
+                          }
+                          setForm({
+                            ...form,
+                            geo_filters: [...existing, { country_code: cc, ...(newGeoCity.trim() ? { city_name: newGeoCity.trim() } : {}) }],
+                          })
+                          setNewGeoCountry("")
+                          setNewGeoCity("")
+                        }
+                      }}
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1 flex-[2]">
+                    <Label htmlFor="new-geo-city" className="text-xs">City (optional)</Label>
+                    <Input
+                      id="new-geo-city"
+                      placeholder="Leave empty for whole country"
+                      value={newGeoCity}
+                      onChange={e => setNewGeoCity(e.target.value)}
+                    />
+                  </div>
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => {
+                      const cc = newGeoCountry.trim().toUpperCase()
+                      if (!cc) { toast.error("Enter a country code"); return }
+                      const existing = form.geo_filters ?? []
+                      if (existing.some(f => f.country_code === cc && (f.city_name ?? "") === newGeoCity.trim())) {
+                        toast.error("Already added")
+                        return
+                      }
+                      setForm({
+                        ...form,
+                        geo_filters: [...existing, { country_code: cc, ...(newGeoCity.trim() ? { city_name: newGeoCity.trim() } : {}) }],
+                      })
+                      setNewGeoCountry("")
+                      setNewGeoCity("")
+                    }}
+                  >
+                    <Plus className="h-4 w-4 mr-1" /> Add
+                  </Button>
+                </div>
+
+                {/* Quick-pick common countries from existing proxy inventory */}
+                {geoCountries.length > 0 && (
+                  <div className="pt-2 border-t mt-1 flex flex-col gap-1.5">
+                    <Label className="text-xs text-muted-foreground">Quick pick from inventory</Label>
+                    <div className="flex flex-wrap gap-1">
+                      {geoCountries.slice(0, 12).map(gc => {
+                        const already = (form.geo_filters ?? []).some(f => f.country_code === gc.country_code && !f.city_name)
+                        return (
+                          <Button
+                            key={gc.country_code}
+                            type="button"
+                            size="sm"
+                            variant={already ? "secondary" : "outline"}
+                            disabled={already}
+                            className="h-6 px-2 text-xs"
+                            onClick={() => setForm({
+                              ...form,
+                              geo_filters: [...(form.geo_filters ?? []), { country_code: gc.country_code }],
+                            })}
+                            title={`${gc.country_name ?? gc.country_code} — ${gc.total} proxies`}
+                          >
+                            <img src={FLAG_CDN(gc.country_code)} alt={gc.country_code} className="h-3 mr-1" />
+                            {gc.country_code}
+                            <span className="ml-1 text-muted-foreground">({gc.total})</span>
+                          </Button>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )}
               </div>
 
               <div className="flex flex-col gap-1.5">

--- a/dashboard/app/dashboard/sources/page.tsx
+++ b/dashboard/app/dashboard/sources/page.tsx
@@ -31,6 +31,8 @@ const DEFAULT_FORM: CreateSourceRequest = {
   protocol: "http",
   enabled: true,
   interval_minutes: 60,
+  cleanup_enabled: false,
+  cleanup_days: 7,
 }
 
 export default function SourcesPage() {
@@ -71,6 +73,8 @@ export default function SourcesPage() {
       protocol: s.protocol,
       enabled: s.enabled,
       interval_minutes: s.interval_minutes,
+      cleanup_enabled: s.cleanup_enabled,
+      cleanup_days: s.cleanup_days || 7,
     })
     setDialogOpen(true)
   }
@@ -245,8 +249,10 @@ export default function SourcesPage() {
                   <TableHead>Protocol</TableHead>
                   <TableHead>Interval</TableHead>
                   <TableHead>Last Fetch</TableHead>
-                  <TableHead>Imported</TableHead>
+                  <TableHead title="Total lines returned by the source on last fetch">Total</TableHead>
+                  <TableHead title="Newly created proxies on last fetch">Imported</TableHead>
                   <TableHead>Status</TableHead>
+                  <TableHead title="Per-source auto-cleanup threshold (days)">Cleanup</TableHead>
                   <TableHead>Enabled</TableHead>
                   <TableHead className="text-right">Actions</TableHead>
                 </TableRow>
@@ -273,6 +279,9 @@ export default function SourcesPage() {
                       {formatDate(s.last_fetched_at)}
                     </TableCell>
                     <TableCell>
+                      <span className="font-semibold">{s.last_total.toLocaleString()}</span>
+                    </TableCell>
+                    <TableCell>
                       <span className="font-semibold">{s.last_count.toLocaleString()}</span>
                     </TableCell>
                     <TableCell>
@@ -286,6 +295,15 @@ export default function SourcesPage() {
                           <CheckCircle2 className="h-3 w-3" />
                           OK
                         </span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {s.cleanup_enabled ? (
+                        <Badge variant="outline" className="text-xs" title="Delete proxies missing from fetch for this many days">
+                          {s.cleanup_days}d
+                        </Badge>
                       ) : (
                         <span className="text-xs text-muted-foreground">—</span>
                       )}
@@ -391,6 +409,38 @@ export default function SourcesPage() {
                 onCheckedChange={v => setForm({ ...form, enabled: v })}
               />
               <Label htmlFor="src-enabled">Enabled</Label>
+            </div>
+
+            {/* Soft auto-cleanup — per-source */}
+            <div className="border-t pt-4 flex flex-col gap-3">
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="src-cleanup"
+                  checked={!!form.cleanup_enabled}
+                  onCheckedChange={v => setForm({ ...form, cleanup_enabled: v })}
+                />
+                <Label htmlFor="src-cleanup">Auto-cleanup stale proxies</Label>
+              </div>
+              <p className="text-xs text-muted-foreground -mt-1">
+                Delete proxies that have been missing from this source's fetch for longer than the threshold below.
+                Proxies still in the fetch response are never deleted.
+              </p>
+              {form.cleanup_enabled && (
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="src-cleanup-days">Delete after (days)</Label>
+                  <Input
+                    id="src-cleanup-days"
+                    type="number"
+                    min={1}
+                    max={365}
+                    value={form.cleanup_days ?? 7}
+                    onChange={e => setForm({
+                      ...form,
+                      cleanup_days: Math.max(1, Math.min(365, parseInt(e.target.value) || 7)),
+                    })}
+                  />
+                </div>
+              )}
             </div>
           </div>
           <DialogFooter>

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -186,8 +186,11 @@ export interface ProxySource {
   enabled: boolean
   interval_minutes: number
   last_fetched_at?: string
-  last_count: number
+  last_count: number        // newly imported on last fetch
+  last_total: number        // total lines returned on last fetch
   last_error?: string
+  cleanup_enabled: boolean
+  cleanup_days: number
   created_at: string
   updated_at: string
 }
@@ -198,6 +201,8 @@ export interface CreateSourceRequest {
   protocol: "http" | "https" | "socks4" | "socks4a" | "socks5"
   enabled: boolean
   interval_minutes: number
+  cleanup_enabled?: boolean
+  cleanup_days?: number
 }
 
 export interface UpdateSourceRequest {
@@ -206,6 +211,8 @@ export interface UpdateSourceRequest {
   protocol?: string
   enabled?: boolean
   interval_minutes?: number
+  cleanup_enabled?: boolean
+  cleanup_days?: number
 }
 
 // ── Proxy Pools ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR combines and supersedes #29. It fixes **20 bugs**, replaces the goproxy dependency with a custom high-performance proxy engine using Linux splice(2) for zero-copy tunneling, adds per-source soft cleanup of stale proxies, instant health check on newly synced pool members, and ships 31 tests.

### New: auto-HC on newly synced pool members (commit 585ad14)

**Problem**: when a new proxy is imported from a source and auto-sync adds it to a pool, it sits at `status='idle'` until the next scheduled pool health check cron tick (up to ~30 min). Newly bought proxies are invisible in `active/failed` counters and excluded from rotation until that tick fires.

**Fix**: `PoolRepository.SyncPoolByFilters` now returns the list of newly-added proxy IDs (diff between current membership and filter result). `PoolService.runAutoSync` fires an immediate, scoped health check on just those IDs — no wasted work on already-tested members. Proxies flip from idle → active/failed within ~1 minute instead of up to 30 minutes.

Signature change: `SyncPoolByFilters (int, error)` → `(int, []int, error)`. Both internal callers updated.

### New: per-source soft cleanup + Total column (commit f68c92f)

The Sources table previously showed only `Imported` (new proxies created this fetch), which drops to 0 once a source stabilises — giving no visibility into whether the source is still healthy. Stale proxies also accumulated forever with no built-in way to prune them.

- **`Total` column** — total lines the source returned on last fetch (the universe), next to `Imported` (the delta).
- **Per-source soft auto-cleanup** — each source has its own `cleanup_enabled` toggle and `cleanup_days` threshold (1-365, default 7).
  - Every fetch stamps `proxies.last_seen_at = NOW()` for addresses in the response.
  - On sources with cleanup enabled, proxies whose `last_seen_at` is older than `cleanup_days` get deleted.
  - A single bad fetch can't wipe a pool — only proxies absent for N days go.
- Defaults `cleanup_enabled=false` mean existing sources are unchanged — opt-in only.
- Migration 21 adds `proxy_sources.{last_total,cleanup_enabled,cleanup_days}` and `proxies.last_seen_at` with a partial index on `(source_id, last_seen_at)`.

### Engine rewrite: goproxy → custom proxy + splice(2)

- **Replace `elazarl/goproxy`** with custom `net/http.Server`-based proxy router
- **HTTPS CONNECT tunneling** via connection hijacking + `BidirectionalCopy()`
- **Linux splice(2)** for zero-copy TCP-to-TCP transfer (falls back to io.Copy on other OS)
- **Pooled 32KB buffers** via `sync.Pool` to reduce GC pressure
- **`WriteTimeout: 0`** for long-lived CONNECT tunnels (HTTP path uses context timeout)
- **Transport cache** (`sync.Map`) — avoids creating new transport per request
- **Removed all goproxy imports** from 4 files: server.go, handler.go, middleware.go, user_auth.go

### Bug fixes: proxy status management

- **Fix proxies flapping between active/failed** — global periodic health check (5min, 60s timeout) was overriding pool-level health check (10s timeout), putting dead proxies back into rotation and breaking user services. Pool-level cron is now the single source of truth
- **Fix DeleteAll/BulkDelete context cancellation** — client disconnect during a long DELETE (CASCADE on proxy_requests hypertable) caused `context canceled` errors mid-operation. Now uses detached context with 5-10min timeout
- **Fix proxies stuck as 'failed'** — `UpdateProxyStatus("failed")` was called on first failure, bypassing the 3-consecutive-failures threshold
- **Fix debug `fmt.Printf("[PROXY POOL]")` in rotation.go** — was printing to stdout on every request

### Bug fixes (from #29, included here)

- **Fix pool health check missing proxy auth** — proxy URLs built without username/password
- **Fix settings reload** — changes saved to DB but proxy server kept stale in-memory values

### Bug fixes (original batch)

- **Batch log INSERT** — replaces per-request INSERT with buffered batch writer (200 rows/flush, 2s interval)
- **Fix Debug() logger hook** — was triggering DB hooks as "info" level
- **Downgrade 15+ per-request INFO logs to DEBUG**
- **Fix log_cleanup interval bug** — interval changes were never applied
- **Fix SQL string interpolation** — replaced `fmt.Sprintf` with parameterized queries
- **Fix HTTP CONNECT status parsing** — `strings.Contains("200")` accepted 1200, 4200, etc.
- **Fix geoip.go double API calls** — results discarded, then same API called again
- **Fix pickProxy hardcoded 10-attempt limit** — now uses actual pool size
- **Fix silent error swallowing** in 3 places
- **Fix healthcheck.go mutating shared TLS config**

### Performance optimizations

- **Cache `http.Transport` per proxy** via `sync.Map`
- **Share single `tls.Config`** across all transports
- **Increase connection pool limits** — MaxIdleConns 100→256, MaxIdleConnsPerHost 10→32
- **Replace `crypto/rand` with `math/rand/v2`** for proxy selection
- **Pool `map[int]bool`** via `sync.Pool`
- **Add `/debug/pprof/*` endpoints** for runtime profiling

### Test suite (31 tests)

| File | Tests | Coverage |
|------|-------|----------|
| `middleware_test.go` | 10 | Auth (enable/disable/valid/invalid/update/strip) + Rate limit (per-IP/burst/cleanup) |
| `tunnel_test.go` | 3 | Basic bidirectional, 10MB SHA256 integrity, half-close propagation |
| `connect_test.go` | 7 | HTTP CONNECT handshake, auth, rejection, SOCKS5, protocol routing |
| `transport_test.go` | 6 | Cache hit/miss, HTTP/SOCKS5/unsupported protocols, auth |
| `server_test.go` | 5 | Router dispatch, auth reject, rate limit, writeHTTPResponse |

### Production results

| Metric | Before | After |
|--------|--------|-------|
| Newly-synced proxy wait | up to 30 min idle | ~1 min idle → active/failed |
| Proxy status stability | flapping 31↔113 active every 5min | stable 31 active / 70 failed |
| Stale proxy pruning | never | per-source cron (opt-in) |
| Source inventory visibility | Imported only (= 0 at steady state) | Total + Imported |
| Failed proxy recovery | stuck forever after one timeout | recovers via per-pool cron |
| DeleteAll/BulkDelete | context canceled errors | completes successfully |
| DB log writes/10s | 2,862 | 1 |
| TimescaleDB disk | 42 GB (growing ~170 GB/day) | 11 MB (stable) |
| goproxy dependency | yes (io.Copy bottleneck) | removed (splice zero-copy) |
| Test coverage | 0 tests | 31 tests |

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./internal/proxy/ -v` — 31/31 PASS
- [x] `go vet ./...` — clean
- [x] Docker build with `CGO_ENABLED=0` — passes (splice uses x/sys/unix)
- [x] Migration 21 applies cleanly over existing 20-migration chain
- [x] Deployed to production under 300+ req/sec sustained load
- [x] Proxy rotation verified: 5 requests → 5 different IPs
- [x] CONNECT tunneling works (gsa.apple.com:443)
- [x] Disk growth stopped (42 GB → 11 MB, stable)
- [x] Status flapping eliminated — pool check is authoritative
- [x] Cleanup disabled by default → existing sources unchanged
- [x] Newly-imported proxies auto-HC within ~1min — verified on prod (14 RU proxies flipped idle→active after auto-sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)