### PR TITLE
Feat/parse proxy colon format

### DIFF
--- a/core/internal/services/source_service.go
+++ b/core/internal/services/source_service.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -27,8 +29,10 @@ type parsedProxy struct {
 // Supported formats (auth is always optional):
 //
 //	host:port
+//	host:port:user:pass
 //	user:pass@host:port
 //	protocol://host:port
+//	protocol://host:port:user:pass
 //	protocol://user:pass@host:port
 func parseProxyLine(line string) (parsedProxy, bool) {
 	line = strings.TrimSpace(line)
@@ -49,6 +53,35 @@ func parseProxyLine(line string) (parsedProxy, bool) {
 			// Unknown scheme — treat whole thing as address and hope for the best
 		}
 		line = line[idx+3:]
+	}
+
+	// ── 1.5 host:port:user:pass — colon-separated creds ──────────────────
+	// Disambiguated by validating the port: only triggers when the segment
+	// between the first two ':' parses as a 1–65535 integer. Skipped for
+	// inputs containing '@' (handled by step 2) and bracketed IPv6 hosts.
+	if !strings.ContainsRune(line, '@') && !strings.HasPrefix(line, "[") {
+		if i1 := strings.IndexByte(line, ':'); i1 > 0 {
+			rest := line[i1+1:]
+			if i2 := strings.IndexByte(rest, ':'); i2 > 0 {
+				host := line[:i1]
+				portStr := rest[:i2]
+				tail := rest[i2+1:]
+				if port, err := strconv.Atoi(portStr); err == nil && port >= 1 && port <= 65535 && isValidProxyHost(host) {
+					addr := host + ":" + portStr
+					if iu := strings.IndexByte(tail, ':'); iu > 0 {
+						u := tail[:iu]
+						p := tail[iu+1:]
+						return parsedProxy{
+							address:  addr,
+							protocol: proto,
+							username: &u,
+							password: &p,
+						}, true
+					}
+					// No second ':' in tail → not the 4-segment form; fall through.
+				}
+			}
+		}
 	}
 
 	// ── 2. Try url.Parse for user:pass@host:port ─────────────────────────
@@ -83,6 +116,29 @@ func parseProxyLine(line string) (parsedProxy, bool) {
 	}
 
 	return parsedProxy{}, false
+}
+
+// isValidProxyHost reports whether s looks like a usable proxy host:
+// a non-empty IPv4/IPv6 literal or a hostname-shaped token (letters,
+// digits, dots, hyphens — no spaces or URL metacharacters).
+func isValidProxyHost(s string) bool {
+	if s == "" || strings.ContainsAny(s, " \t\r\n/?#@") {
+		return false
+	}
+	if net.ParseIP(s) != nil {
+		return true
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '-', r == '.', r == '_':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // ProxyTester is the subset of HealthChecker used by SourceService.

--- a/core/internal/services/source_service.go
+++ b/core/internal/services/source_service.go
@@ -63,16 +63,17 @@ func parseProxyLine(line string) (parsedProxy, bool) {
 		if i1 := strings.IndexByte(line, ':'); i1 > 0 {
 			rest := line[i1+1:]
 			if i2 := strings.IndexByte(rest, ':'); i2 > 0 {
-				host := line[:i1]
 				portStr := rest[:i2]
-				tail := rest[i2+1:]
+				host := line[:i1]
+
 				if port, err := strconv.Atoi(portStr); err == nil && port >= 1 && port <= 65535 && isValidProxyHost(host) {
-					addr := host + ":" + portStr
+					tail := rest[i2+1:]
 					if iu := strings.IndexByte(tail, ':'); iu > 0 {
 						u := tail[:iu]
 						p := tail[iu+1:]
+
 						return parsedProxy{
-							address:  addr,
+							address:  host + ":" + portStr,
 							protocol: proto,
 							username: &u,
 							password: &p,
@@ -97,11 +98,13 @@ func parseProxyLine(line string) (parsedProxy, bool) {
 				pass = &p
 			}
 		}
+
 		host := parsed.Host
 		// url.Parse puts host:port in Host
 		if !strings.Contains(host, ":") {
 			return parsedProxy{}, false // no port — unusable
 		}
+
 		return parsedProxy{
 			address:  host,
 			protocol: proto,
@@ -125,9 +128,11 @@ func isValidProxyHost(s string) bool {
 	if s == "" || strings.ContainsAny(s, " \t\r\n/?#@") {
 		return false
 	}
+
 	if net.ParseIP(s) != nil {
 		return true
 	}
+
 	for _, r := range s {
 		switch {
 		case r >= 'a' && r <= 'z',
@@ -138,6 +143,7 @@ func isValidProxyHost(s string) bool {
 			return false
 		}
 	}
+
 	return true
 }
 

--- a/core/internal/services/source_service_test.go
+++ b/core/internal/services/source_service_test.go
@@ -1,0 +1,134 @@
+package services
+
+import "testing"
+
+func strp(s string) *string { return &s }
+
+func deref(p *string) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return *p
+}
+
+func TestParseProxyLine(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		ok   bool
+		want parsedProxy
+	}{
+		// ── existing formats (regression) ──────────────────────────
+		{
+			name: "bare host:port (IPv4)",
+			line: "1.2.3.4:8080",
+			ok:   true,
+			want: parsedProxy{address: "1.2.3.4:8080"},
+		},
+		{
+			name: "bare host:port (hostname)",
+			line: "proxy.example.com:3128",
+			ok:   true,
+			want: parsedProxy{address: "proxy.example.com:3128"},
+		},
+		{
+			name: "userinfo@host:port",
+			line: "bob:secret@1.2.3.4:8080",
+			ok:   true,
+			want: parsedProxy{
+				address:  "1.2.3.4:8080",
+				username: strp("bob"),
+				password: strp("secret"),
+			},
+		},
+		{
+			name: "scheme + host:port",
+			line: "http://1.2.3.4:8080",
+			ok:   true,
+			want: parsedProxy{address: "1.2.3.4:8080", protocol: "http"},
+		},
+		{
+			name: "scheme + userinfo + host:port",
+			line: "socks5://alice:p4ss@host.example.com:1080",
+			ok:   true,
+			want: parsedProxy{
+				address:  "host.example.com:1080",
+				protocol: "socks5",
+				username: strp("alice"),
+				password: strp("p4ss"),
+			},
+		},
+
+		// ── NEW: host:port:user:pass ───────────────────────────────
+		{
+			name: "colon-separated creds (IPv4)",
+			line: "10.1.2.4:6511:username:password",
+			ok:   true,
+			want: parsedProxy{
+				address:  "10.1.2.4:6511",
+				username: strp("username"),
+				password: strp("password"),
+			},
+		},
+		{
+			name: "colon-separated creds (hostname)",
+			line: "proxy.example.com:3128:bob:secret",
+			ok:   true,
+			want: parsedProxy{
+				address:  "proxy.example.com:3128",
+				username: strp("bob"),
+				password: strp("secret"),
+			},
+		},
+		{
+			name: "colon-separated creds with ':' in password",
+			line: "10.1.2.4:6511:bob:pa:ss:word",
+			ok:   true,
+			want: parsedProxy{
+				address:  "10.1.2.4:6511",
+				username: strp("bob"),
+				password: strp("pa:ss:word"),
+			},
+		},
+		{
+			name: "scheme + colon-separated creds",
+			line: "http://10.1.2.4:6511:bob:secret",
+			ok:   true,
+			want: parsedProxy{
+				address:  "10.1.2.4:6511",
+				protocol: "http",
+				username: strp("bob"),
+				password: strp("secret"),
+			},
+		},
+
+		// ── rejections / fallthrough ───────────────────────────────
+		{name: "empty", line: "", ok: false},
+		{name: "comment", line: "# 1.2.3.4:8080", ok: false},
+		{name: "host without port", line: "hostonly", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseProxyLine(tt.line)
+			if ok != tt.ok {
+				t.Fatalf("ok = %v, want %v (got=%+v)", ok, tt.ok, got)
+			}
+			if !ok {
+				return
+			}
+			if got.address != tt.want.address {
+				t.Errorf("address = %q, want %q", got.address, tt.want.address)
+			}
+			if got.protocol != tt.want.protocol {
+				t.Errorf("protocol = %q, want %q", got.protocol, tt.want.protocol)
+			}
+			if deref(got.username) != deref(tt.want.username) {
+				t.Errorf("username = %s, want %s", deref(got.username), deref(tt.want.username))
+			}
+			if deref(got.password) != deref(tt.want.password) {
+				t.Errorf("password = %s, want %s", deref(got.password), deref(tt.want.password))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

  Adds support for the colon-separated proxy line format `host:port:user:pass` (and `scheme://host:port:user:pass`), which some providers use instead of the standard `user:pass@host:port` form.
  Previously these lines were imported with credentials silently stuffed into the address field.

  ## Motivation

  A provider returns proxies as `10.1.2.4:6511:username:password`. The old `parseProxyLine` ran the line through `url.Parse("x://" + line)`, which has no idea how to split `:user:pass` from
  `host:port`, so the proxy was saved with an unusable address (`10.1.2.4:6511:username:password`) and no credentials.

  ## Approach

  Added a new pre-`url.Parse` branch in `parseProxyLine` (`core/internal/services/source_service.go`):

  1. Skip when the line contains `@` (handled by the existing userinfo branch) or starts with `[` (bracketed IPv6).
  2. Split on the first two `:` to isolate `host`, `port`, and the credentials tail.
  3. **Validate strictly** — port must parse as an integer in `1–65535`, and host must pass `isValidProxyHost` (IPv4/IPv6 literal or a hostname-shaped token). Strict validation is what disambiguates
  `host:port:user:pass` from a malformed `host:port`.
  4. Split the credentials tail on the **first** `:` only, so passwords containing `:` survive intact (`bob:pa:ss:word` → user=`bob`, pass=`pa:ss:word`).
  5. If validation fails, fall through to the existing logic — no regression for old formats.

  `isValidProxyHost` is a small helper that accepts IPs via `net.ParseIP` or hostname-shaped tokens (letters/digits/`.`/`-`/`_`), rejecting spaces and URL metacharacters.

  ## Tests
  Previously these lines were imported with credentials silently stuffed into the address field.

  ## Motivation

  A provider returns proxies as `10.1.2.4:6511:username:password`. The old `parseProxyLine` ran the line through `url.Parse("x://" + line)`, which has no idea how to split `:user:pass` from
  `host:port`, so the proxy was saved with an unusable address (`10.1.2.4:6511:username:password`) and no credentials.

  ## Approach

  Added a new pre-`url.Parse` branch in `parseProxyLine` (`core/internal/services/source_service.go`):

  1. Skip when the line contains `@` (handled by the existing userinfo branch) or starts with `[` (bracketed IPv6).
  2. Split on the first two `:` to isolate `host`, `port`, and the credentials tail.
  3. **Validate strictly** — port must parse as an integer in `1–65535`, and host must pass `isValidProxyHost` (IPv4/IPv6 literal or a hostname-shaped token). Strict validation is what disambiguates
  `host:port:user:pass` from a malformed `host:port`.
  4. Split the credentials tail on the **first** `:` only, so passwords containing `:` survive intact (`bob:pa:ss:word` → user=`bob`, pass=`pa:ss:word`).
  5. If validation fails, fall through to the existing logic — no regression for old formats.

  `isValidProxyHost` is a small helper that accepts IPs via `net.ParseIP` or hostname-shaped tokens (letters/digits/`.`/`-`/`_`), rejecting spaces and URL metacharacters.

  ## Tests

  New table-driven `TestParseProxyLine` in `core/internal/services/source_service_test.go` covering 12 cases:

  - Regression: bare `host:port` (IPv4 + hostname), `user:pass@host:port`, `scheme://host:port`, `scheme://user:pass@host:port`
  - New format: `host:port:user:pass` (IPv4 + hostname), password with embedded `:`, `scheme://host:port:user:pass`
  - Rejections: empty line, comment, host without port

  ## Test plan

  - [x] `go test ./...` — green
  - [x] `go vet ./...` — clean
  - [x] `go build ./...` — clean
  - [x] Import a source returning `host:port:user:pass` lines and confirm proxies land with creds populated
  - [x] Import a source in the old `user:pass@host:port` format and confirm no regression
