### PR TITLE
feat: add strict_tls health check setting to catch expired-cert/MITM proxies

### DIFF
--- a/core/internal/database/migrations.go
+++ b/core/internal/database/migrations.go
@@ -532,6 +532,20 @@ var migrations = []Migration{
 				DROP COLUMN IF EXISTS allow_working_proxies_export;
 		`,
 	},
+	{
+		Version:     24,
+		Description: "Add strict_tls setting to healthcheck (default false for backward compatibility)",
+		Up: `
+			UPDATE settings
+			SET value = jsonb_set(value, '{strict_tls}', 'false', true)
+			WHERE key = 'healthcheck';
+		`,
+		Down: `
+			UPDATE settings
+			SET value = value - 'strict_tls'
+			WHERE key = 'healthcheck';
+		`,
+	},
 }
 
 // Migrate runs all pending migrations

--- a/core/internal/models/settings.go
+++ b/core/internal/models/settings.go
@@ -51,11 +51,12 @@ type RateLimitSettings struct {
 
 // HealthCheckSettings represents health check configuration
 type HealthCheckSettings struct {
-	Timeout int      `json:"timeout"`
-	Workers int      `json:"workers"`
-	URL     string   `json:"url"`
-	Status  int      `json:"status"`
-	Headers []string `json:"headers"`
+	Timeout   int      `json:"timeout"`
+	Workers   int      `json:"workers"`
+	URL       string   `json:"url"`
+	Status    int      `json:"status"`
+	Headers   []string `json:"headers"`
+	StrictTLS bool     `json:"strict_tls"` // Enable real TLS certificate validation during health checks
 }
 
 // LogRetentionSettings represents log retention and cleanup configuration

--- a/core/internal/proxy/healthcheck.go
+++ b/core/internal/proxy/healthcheck.go
@@ -91,18 +91,26 @@ func (h *HealthChecker) CheckProxy(ctx context.Context, proxy *models.Proxy) (*m
 	// done so they don't linger ~90s each run (AUD-41).
 	defer transport.CloseIdleConnections()
 
-	// Override TLS config for health checks to be maximally permissive
+	// StrictTLS (default false) keeps the legacy permissive behavior; when
+	// enabled, real certificate validation catches proxies that intercept TLS
+	// with expired/invalid certs but would otherwise pass the health check.
 	if transport.TLSClientConfig == nil {
 		transport.TLSClientConfig = &tls.Config{}
 	}
-	transport.TLSClientConfig.InsecureSkipVerify = true
-	transport.TLSClientConfig.MinVersion = 0     // Allow all TLS versions including SSLv3
-	transport.TLSClientConfig.MaxVersion = 0     // No maximum version restriction
-	transport.TLSClientConfig.CipherSuites = nil // Accept all cipher suites
-	// This callback allows us to accept even unparseable certificates
-	transport.TLSClientConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-		// Always return nil to accept any certificate, even malformed ones
-		return nil
+	if settings.StrictTLS {
+		transport.TLSClientConfig.InsecureSkipVerify = false
+		transport.TLSClientConfig.VerifyPeerCertificate = nil
+		transport.TLSClientConfig.MinVersion = tls.VersionTLS12
+	} else {
+		transport.TLSClientConfig.InsecureSkipVerify = true
+		transport.TLSClientConfig.MinVersion = 0     // Allow all TLS versions including SSLv3
+		transport.TLSClientConfig.MaxVersion = 0     // No maximum version restriction
+		transport.TLSClientConfig.CipherSuites = nil // Accept all cipher suites
+		// This callback allows us to accept even unparseable certificates
+		transport.TLSClientConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+			// Always return nil to accept any certificate, even malformed ones
+			return nil
+		}
 	}
 
 	client := &http.Client{
@@ -139,7 +147,11 @@ func (h *HealthChecker) CheckProxy(ctx context.Context, proxy *models.Proxy) (*m
 
 		// Make TLS errors more user-friendly
 		if strings.Contains(errMsg, "x509:") || strings.Contains(errMsg, "tls:") {
-			errMsg = fmt.Sprintf("TLS/SSL error: %s (Note: Certificate verification is disabled, but proxy may have issues)", err.Error())
+			if settings.StrictTLS {
+				errMsg = fmt.Sprintf("TLS/SSL error: %s", err.Error())
+			} else {
+				errMsg = fmt.Sprintf("TLS/SSL error: %s (Note: Certificate verification is disabled, but proxy may have issues)", err.Error())
+			}
 		} else if strings.Contains(errMsg, "timeout") {
 			errMsg = fmt.Sprintf("Connection timeout after %ds", settings.Timeout)
 		} else if strings.Contains(errMsg, "connection refused") {

--- a/core/internal/proxy/healthcheck.go
+++ b/core/internal/proxy/healthcheck.go
@@ -97,15 +97,17 @@ func (h *HealthChecker) CheckProxy(ctx context.Context, proxy *models.Proxy) (*m
 	if transport.TLSClientConfig == nil {
 		transport.TLSClientConfig = &tls.Config{}
 	}
+	// Go's defaults: minimum TLS 1.2, tracking future Go releases. The shared
+	// transport pins TLS 1.0 for legacy proxies, so reset it here.
+	transport.TLSClientConfig.MinVersion = 0
+	transport.TLSClientConfig.MaxVersion = 0
+	transport.TLSClientConfig.CipherSuites = nil
+
 	if settings.StrictTLS {
 		transport.TLSClientConfig.InsecureSkipVerify = false
 		transport.TLSClientConfig.VerifyPeerCertificate = nil
-		transport.TLSClientConfig.MinVersion = tls.VersionTLS12
 	} else {
 		transport.TLSClientConfig.InsecureSkipVerify = true
-		transport.TLSClientConfig.MinVersion = 0     // Go's default minimum TLS version
-		transport.TLSClientConfig.MaxVersion = 0     // Go's default maximum TLS version
-		transport.TLSClientConfig.CipherSuites = nil // Go's default cipher suites
 		// This callback allows us to accept even unparseable certificates
 		transport.TLSClientConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			// Always return nil to accept any certificate, even malformed ones

--- a/core/internal/proxy/healthcheck.go
+++ b/core/internal/proxy/healthcheck.go
@@ -103,9 +103,9 @@ func (h *HealthChecker) CheckProxy(ctx context.Context, proxy *models.Proxy) (*m
 		transport.TLSClientConfig.MinVersion = tls.VersionTLS12
 	} else {
 		transport.TLSClientConfig.InsecureSkipVerify = true
-		transport.TLSClientConfig.MinVersion = 0     // Allow all TLS versions including SSLv3
-		transport.TLSClientConfig.MaxVersion = 0     // No maximum version restriction
-		transport.TLSClientConfig.CipherSuites = nil // Accept all cipher suites
+		transport.TLSClientConfig.MinVersion = 0     // Go's default minimum TLS version
+		transport.TLSClientConfig.MaxVersion = 0     // Go's default maximum TLS version
+		transport.TLSClientConfig.CipherSuites = nil // Go's default cipher suites
 		// This callback allows us to accept even unparseable certificates
 		transport.TLSClientConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 			// Always return nil to accept any certificate, even malformed ones

--- a/core/internal/proxy/healthcheck_test.go
+++ b/core/internal/proxy/healthcheck_test.go
@@ -142,7 +142,11 @@ func TestHealthCheckStrictTLS(t *testing.T) {
 			}
 			if tc.wantErr != "" {
 				if result.Error == nil || !strings.Contains(*result.Error, tc.wantErr) {
-					t.Fatalf("error = %q, want it to contain %q", *result.Error, tc.wantErr)
+					errStr := "nil"
+					if result.Error != nil {
+						errStr = *result.Error
+					}
+					t.Fatalf("error = %q, want it to contain %q", errStr, tc.wantErr)
 				}
 			}
 		})

--- a/core/internal/proxy/healthcheck_test.go
+++ b/core/internal/proxy/healthcheck_test.go
@@ -1,0 +1,150 @@
+package proxy
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alpkeskin/rota/core/internal/database"
+	"github.com/alpkeskin/rota/core/internal/models"
+	"github.com/alpkeskin/rota/core/internal/repository"
+	"github.com/alpkeskin/rota/core/pkg/logger"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// newExpiredTLSServer starts an HTTPS server whose certificate has already
+// expired — simulating a proxy intercepting TLS with a stale certificate.
+// (It is also self-signed, so strict mode rejects it with "unknown authority"
+// rather than "expired" — the rejection is what matters.)
+func newExpiredTLSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "expired-proxy"},
+		NotBefore:    time.Now().Add(-48 * time.Hour),
+		NotAfter:     time.Now().Add(-24 * time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	ts.TLS = &tls.Config{Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: priv}}}
+	ts.StartTLS()
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// newTunnelProxy starts a minimal HTTP CONNECT proxy that tunnels bytes to the
+// requested host, so the health check's TLS handshake happens end-to-end
+// against the target server.
+func newTunnelProxy(t *testing.T) string {
+	t.Helper()
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodConnect {
+			http.Error(w, "CONNECT only", http.StatusBadRequest)
+			return
+		}
+		target, err := net.Dial("tcp", r.Host)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			target.Close()
+			http.Error(w, "hijacking unsupported", http.StatusInternalServerError)
+			return
+		}
+		client, _, err := hj.Hijack()
+		if err != nil {
+			target.Close()
+			return
+		}
+		if _, err := client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
+			target.Close()
+			client.Close()
+			return
+		}
+		go func() { io.Copy(target, client); target.Close(); client.Close() }()
+		go func() { io.Copy(client, target); target.Close(); client.Close() }()
+	}))
+	t.Cleanup(proxy.Close)
+	return strings.TrimPrefix(proxy.URL, "http://")
+}
+
+func TestHealthCheckStrictTLS(t *testing.T) {
+	ts := newExpiredTLSServer(t)
+	proxyAddr := newTunnelProxy(t)
+
+	// Stats writes go to a pool that can't connect; the check result itself
+	// does not depend on them (the writes fail fast and are best-effort).
+	pool, err := pgxpool.New(context.Background(), "postgres://dead:dead@127.0.0.1:1/dead")
+	if err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	defer pool.Close()
+
+	h := &HealthChecker{
+		tracker: NewUsageTracker(repository.NewProxyRepository(&database.DB{Pool: pool})),
+		logger:  logger.New("error"),
+	}
+
+	tests := []struct {
+		name    string
+		strict  bool
+		want    string
+		wantErr string
+	}{
+		{name: "loose accepts expired certificate", strict: false, want: "active"},
+		{name: "strict rejects expired certificate", strict: true, want: "failed", wantErr: "TLS/SSL error"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h.setSettings(&models.HealthCheckSettings{
+				Timeout:   5,
+				Workers:   1,
+				URL:       ts.URL,
+				Status:    http.StatusOK,
+				StrictTLS: tc.strict,
+			})
+
+			result, err := h.CheckProxy(context.Background(), &models.Proxy{
+				ID:       1,
+				Address:  proxyAddr,
+				Protocol: "http",
+			})
+			if err != nil {
+				t.Fatalf("CheckProxy: %v", err)
+			}
+			if result.Status != tc.want {
+				t.Fatalf("status = %q, want %q (error: %v)", result.Status, tc.want, result.Error)
+			}
+			if tc.wantErr != "" {
+				if result.Error == nil || !strings.Contains(*result.Error, tc.wantErr) {
+					t.Fatalf("error = %q, want it to contain %q", *result.Error, tc.wantErr)
+				}
+			}
+		})
+	}
+}

--- a/dashboard/app/dashboard/settings/page.tsx
+++ b/dashboard/app/dashboard/settings/page.tsx
@@ -740,6 +740,25 @@ export default function SettingsPage() {
                 One header per line in format: Key: Value
               </p>
             </div>
+
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="healthcheck-strict-tls">Strict TLS Validation</Label>
+                <p className="text-xs text-muted-foreground">
+                  Reject proxies with expired or invalid certificates
+                </p>
+              </div>
+              <Switch
+                id="healthcheck-strict-tls"
+                checked={settings.healthcheck.strict_tls ?? false}
+                onCheckedChange={(checked) =>
+                  setSettings({
+                    ...settings,
+                    healthcheck: { ...settings.healthcheck, strict_tls: checked },
+                  })
+                }
+              />
+            </div>
           </CardContent>
         </Card>
 

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -123,6 +123,7 @@ export interface Settings {
     url: string
     status: number
     headers: string[]
+    strict_tls: boolean
   }
   log_retention: {
     enabled: boolean


### PR DESCRIPTION
## What

Adds an opt-in **`strict_tls`** toggle to `HealthCheckSettings`. When enabled, the health check performs real TLS certificate validation instead of the current maximally permissive `InsecureSkipVerify: true` + `VerifyPeerCertificate` override.

**Fixes #46**

## Why

The current health check accepts **any** certificate — including expired, self-signed, and MITM-intercepted ones. Proxies doing TLS interception with expired certs pass the health check as "healthy", but real clients (browsers, API clients, etc.) get `CERT_HAS_EXPIRED` / TLS errors when HTTPS traffic is tunneled through them.

## Changes

| File | Change |
|---|---|
| `core/internal/models/settings.go` | Add `StrictTLS bool` to `HealthCheckSettings` |
| `core/internal/database/migrations.go` | Migration v24: add `strict_tls: false` to healthcheck JSONB (backward compatible) |
| `core/internal/proxy/healthcheck.go` | Branch TLS config on `settings.StrictTLS` — strict mode: `InsecureSkipVerify=false`, TLS ≥1.2, no `VerifyPeerCertificate` override |
| `dashboard/app/dashboard/settings/page.tsx` | "Strict TLS Validation" switch in the Health Check card |
| `dashboard/lib/types.ts` | Add `strict_tls` to healthcheck settings type |

## Behavior

- **`strict_tls: false`** (default): identical to current behavior — all certificates accepted (corporate MITM, self-signed, legacy TLS)
- **`strict_tls: true`**: proxies with expired/invalid certificates fail the health check and are removed from rotation

## Verification

- [x] `go build ./...` passes
- [x] `go vet ./internal/proxy/ ./internal/models/ ./internal/database/` passes
- [x] `tsc --noEmit` passes in dashboard
- [x] Migration v24 is idempotent (`jsonb_set` with `create_missing=true`) and has a `Down` migration

## Related

- Original research: Rota health checks hardcode `InsecureSkipVerify: true` + `VerifyPeerCertificate: return nil` (`healthcheck.go`)
- The `CreateProxyTransport` in `transport.go` also sets `InsecureSkipVerify: true`, but that's the HTTP-forwarding path (not CONNECT tunneling) with different tradeoffs — left unchanged, as discussed in the issue