### PR TITLE
ci(release): publish rota-dashboard image to GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,10 +89,83 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+  build-and-push-dashboard:
+    name: Build and Push Dashboard Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+            network=host
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dashboard
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=Rota Dashboard
+            org.opencontainers.image.description=Rota proxy rotation dashboard
+            org.opencontainers.image.vendor=${{ github.repository_owner }}
+
+      # Built WITHOUT build args on purpose: empty NEXT_PUBLIC_API_URL makes the
+      # dashboard call the API same-origin (a reverse proxy in front must route
+      # /api and /ws to the core), and NEXT_PUBLIC_PROXY_PORT falls back to 8000.
+      # This is what makes a single published image deployment-agnostic (#48).
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./dashboard
+          file: ./dashboard/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=dashboard
+          cache-to: type=gha,mode=max,scope=dashboard
+          sbom: true
+          provenance: mode=max
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dashboard
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: [build-and-push, build-and-push-dashboard]
     permissions:
       contents: write
 
@@ -146,4 +219,6 @@ jobs:
           echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.changelog.outputs.current_tag }}" >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dashboard:${{ steps.changelog.outputs.current_tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-dashboard:latest" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Add a `build-and-push-dashboard` job to the release workflow: builds `ghcr.io/alpkeskin/rota-dashboard` (multi-arch amd64+arm64, same semver tag scheme + `latest`, SBOM/provenance/attestation) alongside the core image on every release tag.
- The image is built **without** build args on purpose: empty `NEXT_PUBLIC_API_URL` means same-origin API calls (the reverse proxy in front routes `/api` and `/ws` to the core), which is what makes a single prebuilt image deployment-agnostic.
- `create-release` now waits for both builds; release summary includes dashboard pull commands.

Closes #48

## Notes
- After the first push, the new `rota-dashboard` GHCR package must be made public (new packages default to private).
- Known trade-off: `NEXT_PUBLIC_PROXY_PORT` is baked at build time as 8000; non-default proxy ports show the wrong port in copy-able proxy URLs (cosmetic, can move to runtime config later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)