### PR TITLE
feat(dashboard): expose proxy tags, pool tag/ISP filters and manual membership

### DIFF
--- a/core/docs/swagger.json
+++ b/core/docs/swagger.json
@@ -589,6 +589,53 @@
                 }
             }
         },
+        "/proxies/bulk-tags": {
+            "post": {
+                "description": "Add and/or remove tags on multiple proxies at once",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "proxies"
+                ],
+                "summary": "Bulk update proxy tags",
+                "parameters": [
+                    {
+                        "description": "Proxy IDs and tags to add/remove",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_alpkeskin_rota_core_internal_models.BulkTagProxyRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Update results",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_alpkeskin_rota_core_internal_models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_alpkeskin_rota_core_internal_models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/proxies/export": {
             "get": {
                 "description": "Export proxy list in various formats (txt, json, csv)",
@@ -1289,6 +1336,33 @@
                     "minItems": 1,
                     "items": {
                         "type": "integer"
+                    }
+                }
+            }
+        },
+        "github_com_alpkeskin_rota_core_internal_models.BulkTagProxyRequest": {
+            "type": "object",
+            "required": [
+                "ids"
+            ],
+            "properties": {
+                "ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "add": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "remove": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     }
                 }
             }

--- a/core/internal/api/handlers/proxy_handler.go
+++ b/core/internal/api/handlers/proxy_handler.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/alpkeskin/rota/core/internal/models"
@@ -316,6 +317,57 @@ func (h *ProxyHandler) BulkDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.jsonResponse(w, http.StatusOK, response)
+}
+
+// BulkTag handles bulk tag updates on proxies
+//	@Summary		Bulk update proxy tags
+//	@Description	Add and/or remove tags on multiple proxies at once
+//	@Tags			proxies
+//	@Accept			json
+//	@Produce		json
+//	@Param			request	body		models.BulkTagProxyRequest	true	"Proxy IDs and tags to add/remove"
+//	@Success		200		{object}	map[string]interface{}		"Update results"
+//	@Failure		400		{object}	models.ErrorResponse
+//	@Failure		500		{object}	models.ErrorResponse
+//	@Router			/proxies/bulk-tags [post]
+func (h *ProxyHandler) BulkTag(w http.ResponseWriter, r *http.Request) {
+	var req models.BulkTagProxyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.errorResponse(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	if len(req.IDs) == 0 {
+		h.errorResponse(w, http.StatusBadRequest, "At least one proxy ID is required")
+		return
+	}
+
+	normalize := func(tags []string) []string {
+		out := make([]string, 0, len(tags))
+		for _, t := range tags {
+			if t = strings.TrimSpace(t); t != "" {
+				out = append(out, t)
+			}
+		}
+		return out
+	}
+	add, remove := normalize(req.Add), normalize(req.Remove)
+	if len(add) == 0 && len(remove) == 0 {
+		h.errorResponse(w, http.StatusBadRequest, "At least one tag to add or remove is required")
+		return
+	}
+
+	updated, err := h.proxyRepo.BulkUpdateTags(r.Context(), req.IDs, add, remove)
+	if err != nil {
+		h.logger.Error("failed to bulk update proxy tags", "error", err)
+		h.errorResponse(w, http.StatusInternalServerError, "Failed to update proxy tags")
+		return
+	}
+
+	h.jsonResponse(w, http.StatusOK, map[string]interface{}{
+		"updated": updated,
+		"message": fmt.Sprintf("Successfully updated tags on %d proxies", updated),
+	})
 }
 
 // Test handles proxy testing

--- a/core/internal/api/server.go
+++ b/core/internal/api/server.go
@@ -285,6 +285,7 @@ func (s *Server) setupRoutes() {
 		r.Post("/proxies", s.proxyHandler.Create)
 		r.Post("/proxies/bulk", s.proxyHandler.BulkCreate)
 		r.Post("/proxies/bulk-delete", s.proxyHandler.BulkDelete)
+		r.Post("/proxies/bulk-tags", s.proxyHandler.BulkTag)
 		r.Delete("/proxies", s.proxyHandler.DeleteAll)
 		r.Get("/proxies/export", s.proxyHandler.Export)
 		r.Put("/proxies/{id}", s.proxyHandler.Update)

--- a/core/internal/models/proxy.go
+++ b/core/internal/models/proxy.go
@@ -100,6 +100,13 @@ type BulkDeleteProxyRequest struct {
 	IDs []int `json:"ids" validate:"required,min=1"`
 }
 
+// BulkTagProxyRequest represents a request to add/remove tags on multiple proxies
+type BulkTagProxyRequest struct {
+	IDs    []int    `json:"ids" validate:"required,min=1"`
+	Add    []string `json:"add,omitempty"`
+	Remove []string `json:"remove,omitempty"`
+}
+
 // ProxyTestResult represents the result of testing a proxy
 type ProxyTestResult struct {
 	ID           int        `json:"id"`

--- a/core/internal/repository/proxy_repository.go
+++ b/core/internal/repository/proxy_repository.go
@@ -315,12 +315,14 @@ func (r *ProxyRepository) Update(ctx context.Context, id int, req models.UpdateP
 	if tags == nil {
 		tags = []string{}
 	}
+	// password: nil keeps the stored value (it is never sent back to clients,
+	// so an edit form can't round-trip it); "" clears it explicitly.
 	query := `
 		UPDATE proxies
 		SET address    = COALESCE(NULLIF($1, ''), address),
 		    protocol   = COALESCE(NULLIF($2, ''), protocol),
 		    username   = $3,
-		    password   = $4,
+		    password   = COALESCE($4, password),
 		    tags       = $5,
 		    updated_at = NOW()
 		WHERE id = $6
@@ -341,6 +343,32 @@ func (r *ProxyRepository) Update(ctx context.Context, id int, req models.UpdateP
 	}
 
 	return &p, nil
+}
+
+// BulkUpdateTags adds and/or removes tags on multiple proxies in one statement.
+// Added tags are deduplicated; removals win over additions of the same tag.
+func (r *ProxyRepository) BulkUpdateTags(ctx context.Context, ids []int, add, remove []string) (int, error) {
+	if add == nil {
+		add = []string{}
+	}
+	if remove == nil {
+		remove = []string{}
+	}
+	query := `
+		UPDATE proxies
+		SET tags = (
+			SELECT COALESCE(array_agg(DISTINCT t ORDER BY t), '{}')
+			FROM unnest(COALESCE(tags, '{}') || $2::text[]) AS t
+			WHERE t <> ALL($3::text[])
+		),
+		    updated_at = NOW()
+		WHERE id = ANY($1::int[])
+	`
+	result, err := r.db.Pool.Exec(ctx, query, ids, add, remove)
+	if err != nil {
+		return 0, fmt.Errorf("failed to bulk update tags: %w", err)
+	}
+	return int(result.RowsAffected()), nil
 }
 
 // Delete deletes a proxy by ID

--- a/dashboard/app/dashboard/pools/page.tsx
+++ b/dashboard/app/dashboard/pools/page.tsx
@@ -4,13 +4,13 @@ import { useEffect, useState, useCallback, useRef } from "react"
 import {
   Plus, Trash2, RefreshCw,
   Pencil, Loader2, Layers, ShieldCheck, Globe,
-  Download, Bell, BellOff, Tag,
+  Download, Bell, BellOff, Tag, X,
 } from "lucide-react"
 import { toast } from "sonner"
 import { api } from "@/lib/api"
 import {
   ProxyPool, PoolProxy, GeoSummaryItem, HCJob, CreatePoolRequest,
-  PoolAlertRule, CreatePoolAlertRuleRequest,
+  PoolAlertRule, CreatePoolAlertRuleRequest, Proxy,
 } from "@/lib/types"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -29,6 +29,8 @@ import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { GeoSelector } from "@/components/geo-selector"
+import { TagInput } from "@/components/tag-input"
+import { Checkbox } from "@/components/ui/checkbox"
 
 // ────────────────────────────────────────────────────────────────────────────
 // Types & helpers
@@ -97,6 +99,18 @@ export default function PoolsPage() {
   const [newGeoCountry, setNewGeoCountry] = useState("")
   const [newGeoCity, setNewGeoCity] = useState("")
 
+  // Suggestions for tag / ISP filter inputs (best-effort)
+  const [tagList, setTagList] = useState<string[]>([])
+  const [ispList, setIspList] = useState<string[]>([])
+
+  // Manual "add proxies to pool" picker
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [pickerSearch, setPickerSearch] = useState("")
+  const [pickerResults, setPickerResults] = useState<Proxy[]>([])
+  const [pickerLoading, setPickerLoading] = useState(false)
+  const [pickerSelected, setPickerSelected] = useState<number[]>([])
+  const [addingProxies, setAddingProxies] = useState(false)
+
   // Alert rules
   const [alertRules, setAlertRules] = useState<PoolAlertRule[]>([])
   const [alertDialogOpen, setAlertDialogOpen] = useState(false)
@@ -124,11 +138,19 @@ export default function PoolsPage() {
 
   useEffect(() => { loadAll() }, [loadAll])
 
+  const refreshFilterSuggestions = useCallback(() => {
+    api.getTagList().then(setTagList).catch(() => {})
+    api.getISPList().then(setIspList).catch(() => {})
+  }, [])
+
+  useEffect(() => { refreshFilterSuggestions() }, [refreshFilterSuggestions])
+
   const openCreate = () => {
     setEditPool(null)
     setForm({ ...DEFAULT_POOL_FORM, geo_filters: [] })
     setNewGeoCountry("")
     setNewGeoCity("")
+    refreshFilterSuggestions()
     setDialogOpen(true)
   }
 
@@ -154,6 +176,7 @@ export default function PoolsPage() {
     })
     setNewGeoCountry("")
     setNewGeoCity("")
+    refreshFilterSuggestions()
     setDialogOpen(true)
   }
 
@@ -291,6 +314,64 @@ export default function PoolsPage() {
     }
   }
 
+  // ── Manual pool membership ────────────────────────────────────────────────
+
+  const openPicker = () => {
+    setPickerSearch("")
+    setPickerSelected([])
+    setPickerOpen(true)
+  }
+
+  // Load candidate proxies for the picker (debounced on search input)
+  useEffect(() => {
+    if (!pickerOpen) return
+    let cancelled = false
+    setPickerLoading(true)
+    const timer = setTimeout(async () => {
+      try {
+        const res = await api.getProxies({
+          page: 1,
+          limit: 50,
+          search: pickerSearch.trim() || undefined,
+        })
+        if (!cancelled) setPickerResults(res.proxies)
+      } catch {
+        if (!cancelled) toast.error("Failed to load proxies")
+      } finally {
+        if (!cancelled) setPickerLoading(false)
+      }
+    }, 300)
+    return () => { cancelled = true; clearTimeout(timer) }
+  }, [pickerOpen, pickerSearch])
+
+  const handleAddProxiesToPool = async () => {
+    if (!selectedPool || pickerSelected.length === 0) return
+    setAddingProxies(true)
+    try {
+      const res = await api.addPoolProxies(selectedPool.id, pickerSelected)
+      toast.success(`Added ${res.added} proxies to pool`)
+      setPickerOpen(false)
+      handleSelectPool(selectedPool)
+      loadAll()
+    } catch {
+      toast.error("Failed to add proxies to pool")
+    } finally {
+      setAddingProxies(false)
+    }
+  }
+
+  const handleRemoveProxyFromPool = async (proxyId: number) => {
+    if (!selectedPool) return
+    try {
+      await api.removePoolProxies(selectedPool.id, [proxyId])
+      setPoolProxies(prev => prev.filter(p => p.proxy_id !== proxyId))
+      toast.success("Proxy removed from pool")
+      loadAll()
+    } catch {
+      toast.error("Failed to remove proxy from pool")
+    }
+  }
+
   const stopHcPoll = useCallback(() => {
     if (hcPollRef.current) {
       clearInterval(hcPollRef.current)
@@ -351,7 +432,7 @@ export default function PoolsPage() {
         <div>
           <h1 className="text-2xl font-bold">Proxy Pools</h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Named groups of proxies with geo filters and independent rotation strategies
+            Named groups of proxies with geo, ISP or tag filters and independent rotation strategies
           </p>
         </div>
         <Button size="sm" onClick={openCreate}>
@@ -452,7 +533,7 @@ export default function PoolsPage() {
                             variant="outline" size="sm"
                             onClick={handleSync}
                             disabled={syncing}
-                            title="Re-sync proxies from geo filters"
+                            title="Re-sync proxies from pool filters"
                           >
                             {syncing
                               ? <Loader2 className="h-3 w-3 animate-spin mr-1" />
@@ -570,9 +651,14 @@ export default function PoolsPage() {
                   {/* Proxies in pool */}
                   <Card>
                     <CardHeader className="pb-2">
-                      <CardTitle className="text-sm">
-                        Proxies in pool ({poolProxies.length})
-                      </CardTitle>
+                      <div className="flex items-center justify-between">
+                        <CardTitle className="text-sm">
+                          Proxies in pool ({poolProxies.length})
+                        </CardTitle>
+                        <Button size="sm" variant="outline" onClick={openPicker}>
+                          <Plus className="h-3 w-3 mr-1" />Add Proxies
+                        </Button>
+                      </div>
                     </CardHeader>
                     <CardContent className="p-0">
                       {poolProxiesLoading ? (
@@ -581,7 +667,7 @@ export default function PoolsPage() {
                         </div>
                       ) : poolProxies.length === 0 ? (
                         <p className="text-center py-6 text-sm text-muted-foreground">
-                          No proxies. Use Sync to populate from geo filters.
+                          No proxies. Use Sync to populate from pool filters, or add proxies manually.
                         </p>
                       ) : (
                         <div className="max-h-80 overflow-auto">
@@ -592,6 +678,7 @@ export default function PoolsPage() {
                                 <TableHead className="text-xs">Geo</TableHead>
                                 <TableHead className="text-xs">Status</TableHead>
                                 <TableHead className="text-xs text-right">RT</TableHead>
+                                <TableHead className="w-8" />
                               </TableRow>
                             </TableHeader>
                             <TableBody>
@@ -613,6 +700,16 @@ export default function PoolsPage() {
                                   </TableCell>
                                   <TableCell className="text-xs text-right text-muted-foreground">
                                     {pp.avg_response_time ? `${pp.avg_response_time}ms` : "—"}
+                                  </TableCell>
+                                  <TableCell className="p-0 pr-2 text-right">
+                                    <Button
+                                      variant="ghost" size="icon"
+                                      className="h-6 w-6 text-muted-foreground hover:text-red-500"
+                                      title="Remove from pool"
+                                      onClick={() => handleRemoveProxyFromPool(pp.proxy_id)}
+                                    >
+                                      <X className="h-3 w-3" />
+                                    </Button>
                                   </TableCell>
                                 </TableRow>
                               ))}
@@ -732,7 +829,7 @@ export default function PoolsPage() {
                 <div className="flex flex-wrap gap-1.5 min-h-[28px]">
                   {(form.geo_filters ?? []).length === 0 && (
                     <span className="text-xs text-muted-foreground italic">
-                      No country filters yet — this pool will not sync any proxies. Add at least one below.
+                      No country filters — a pool needs at least one country, ISP or tag filter to sync proxies.
                     </span>
                   )}
                   {(form.geo_filters ?? []).map((f, idx) => (
@@ -849,6 +946,48 @@ export default function PoolsPage() {
                 )}
               </div>
 
+              {/* Tag filters — match proxies by custom tags; works for proxies
+                  without GeoIP data (e.g. local/VPN proxies, issue #45) */}
+              <div className="col-span-2 flex flex-col gap-2 border rounded-md p-3">
+                <div className="flex items-center justify-between">
+                  <Label className="text-sm font-medium flex items-center gap-1.5">
+                    <Tag className="h-3.5 w-3.5" />Tag filters
+                  </Label>
+                  <span className="text-xs text-muted-foreground">
+                    {form.tag_filters?.length ?? 0} filter{(form.tag_filters?.length ?? 0) === 1 ? "" : "s"}
+                  </span>
+                </div>
+                <TagInput
+                  value={form.tag_filters ?? []}
+                  onChange={tag_filters => setForm({ ...form, tag_filters })}
+                  suggestions={tagList}
+                  placeholder="e.g. local-socks"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Matches proxies carrying <strong>all</strong> of these tags — ideal for
+                  local or VPN proxies without GeoIP. Assign tags in Proxy Management.
+                </p>
+              </div>
+
+              {/* ISP filters — substring match against the proxy's ISP */}
+              <div className="col-span-2 flex flex-col gap-2 border rounded-md p-3">
+                <div className="flex items-center justify-between">
+                  <Label className="text-sm font-medium">ISP filters</Label>
+                  <span className="text-xs text-muted-foreground">
+                    {form.isp_filters?.length ?? 0} filter{(form.isp_filters?.length ?? 0) === 1 ? "" : "s"}
+                  </span>
+                </div>
+                <TagInput
+                  value={form.isp_filters ?? []}
+                  onChange={isp_filters => setForm({ ...form, isp_filters })}
+                  suggestions={ispList}
+                  placeholder="e.g. Comcast"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Matches proxies whose ISP contains <strong>any</strong> of these values
+                </p>
+              </div>
+
               <div className="flex flex-col gap-1.5">
                 <Label>Rotation strategy</Label>
                 <Select
@@ -937,6 +1076,78 @@ export default function PoolsPage() {
             <Button onClick={handleSave} disabled={saving}>
               {saving && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
               {editPool ? "Save Changes" : "Create Pool"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Add proxies to pool dialog */}
+      <Dialog open={pickerOpen} onOpenChange={setPickerOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Add proxies to {selectedPool?.name}</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-3 py-2">
+            {selectedPool?.sync_mode !== "manual" && (
+              <p className="text-xs rounded-md border border-yellow-500/40 bg-yellow-500/10 p-2 text-yellow-600 dark:text-yellow-400">
+                This pool is in auto sync mode: the next sync rebuilds membership from
+                the pool&apos;s filters and may remove manually added proxies. Switch the
+                pool to manual sync mode (or add matching tag filters) to keep them.
+              </p>
+            )}
+            <Input
+              placeholder="Search by address…"
+              value={pickerSearch}
+              onChange={e => setPickerSearch(e.target.value)}
+            />
+            <div className="border rounded-md max-h-64 overflow-auto">
+              {pickerLoading ? (
+                <div className="flex justify-center py-8">
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                </div>
+              ) : pickerResults.length === 0 ? (
+                <p className="text-center py-6 text-sm text-muted-foreground">No proxies found</p>
+              ) : (
+                <div className="divide-y">
+                  {pickerResults.map(p => {
+                    const inPool = poolProxies.some(pp => pp.proxy_id === p.id)
+                    const checked = pickerSelected.includes(p.id)
+                    return (
+                      <label
+                        key={p.id}
+                        className={`flex items-center gap-2 px-3 py-1.5 text-xs ${inPool ? "opacity-50" : "cursor-pointer hover:bg-muted/50"}`}
+                      >
+                        <Checkbox
+                          checked={inPool || checked}
+                          disabled={inPool}
+                          onCheckedChange={v => setPickerSelected(prev =>
+                            v ? [...prev, p.id] : prev.filter(id => id !== p.id)
+                          )}
+                        />
+                        <span className="font-mono flex-1 truncate">{p.address}</span>
+                        <Badge variant="outline" className="text-xs uppercase">{p.protocol}</Badge>
+                        {(p.tags ?? []).slice(0, 2).map(t => (
+                          <Badge key={t} variant="secondary" className="text-xs">{t}</Badge>
+                        ))}
+                        <span className={statusColor(p.status)}>{p.status}</span>
+                        {inPool && <span className="text-muted-foreground">in pool</span>}
+                      </label>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPickerOpen(false)} disabled={addingProxies}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleAddProxiesToPool}
+              disabled={addingProxies || pickerSelected.length === 0}
+            >
+              {addingProxies && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+              Add {pickerSelected.length || ""} {pickerSelected.length === 1 ? "Proxy" : "Proxies"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/dashboard/app/dashboard/proxies/page.tsx
+++ b/dashboard/app/dashboard/proxies/page.tsx
@@ -27,6 +27,7 @@ import {
   XCircle,
   AlertCircle,
   Filter,
+  Tag,
 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
@@ -75,6 +76,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { api } from "@/lib/api"
 import { Proxy } from "@/lib/types"
 import { toast } from "@/lib/toast"
+import { TagInput } from "@/components/tag-input"
 
 export default function ProxiesPage() {
   const [data, setData] = React.useState<Proxy[]>([])
@@ -103,7 +105,17 @@ export default function ProxiesPage() {
     protocol: "http" as "http" | "https" | "socks4" | "socks4a" | "socks5",
     username: "",
     password: "",
+    tags: [] as string[],
   })
+
+  // Known tags across all proxies, used as one-click suggestions
+  const [allTags, setAllTags] = React.useState<string[]>([])
+
+  // Bulk tag dialog
+  const [isTagDialogOpen, setIsTagDialogOpen] = React.useState(false)
+  const [bulkAddTags, setBulkAddTags] = React.useState<string[]>([])
+  const [bulkRemoveTags, setBulkRemoveTags] = React.useState<string[]>([])
+  const [isTagging, setIsTagging] = React.useState(false)
 
   // Import modal states
   const [importFile, setImportFile] = React.useState<File | null>(null)
@@ -160,13 +172,26 @@ export default function ProxiesPage() {
     fetchProxies()
   }, [fetchProxies])
 
+  const fetchTagList = React.useCallback(async () => {
+    try {
+      setAllTags(await api.getTagList())
+    } catch {
+      // Suggestions are best-effort; tagging works without them
+    }
+  }, [])
+
+  React.useEffect(() => {
+    fetchTagList()
+  }, [fetchTagList])
+
   const handleAddProxy = async () => {
     try {
       await api.addProxy(newProxy)
       setIsAddDialogOpen(false)
-      setNewProxy({ address: "", protocol: "http", username: "", password: "" })
+      setNewProxy({ address: "", protocol: "http", username: "", password: "", tags: [] })
       toast.success("Proxy added successfully")
       fetchProxies()
+      fetchTagList()
     } catch (error) {
       console.error("Failed to add proxy:", error)
       toast.error("Failed to add proxy", error instanceof Error ? error.message : "Unknown error")
@@ -181,14 +206,45 @@ export default function ProxiesPage() {
         address: editingProxy.address,
         protocol: editingProxy.protocol,
         username: editingProxy.username,
+        tags: editingProxy.tags ?? [],
       })
       setIsEditDialogOpen(false)
       setEditingProxy(null)
       toast.success("Proxy updated successfully")
       fetchProxies()
+      fetchTagList()
     } catch (error) {
       console.error("Failed to update proxy:", error)
       toast.error("Failed to update proxy", error instanceof Error ? error.message : "Unknown error")
+    }
+  }
+
+  const handleBulkTag = async () => {
+    const selectedIds = getSelectedProxyIds()
+    if (selectedIds.length === 0) return
+    if (bulkAddTags.length === 0 && bulkRemoveTags.length === 0) {
+      toast.error("Nothing to do", "Add or remove at least one tag")
+      return
+    }
+
+    setIsTagging(true)
+    try {
+      const res = await api.bulkTagProxies({
+        ids: selectedIds,
+        add: bulkAddTags,
+        remove: bulkRemoveTags,
+      })
+      toast.success(`Tags updated on ${res.updated} proxies`)
+      setIsTagDialogOpen(false)
+      setBulkAddTags([])
+      setBulkRemoveTags([])
+      fetchProxies()
+      fetchTagList()
+    } catch (error) {
+      console.error("Failed to update tags:", error)
+      toast.error("Failed to update tags", error instanceof Error ? error.message : "Unknown error")
+    } finally {
+      setIsTagging(false)
     }
   }
 
@@ -480,6 +536,29 @@ export default function ProxiesPage() {
       ),
     },
     {
+      accessorKey: "tags",
+      header: "Tags",
+      enableSorting: false,
+      cell: ({ row }) => {
+        const tags = (row.getValue("tags") as string[] | undefined) ?? []
+        if (tags.length === 0) {
+          return <span className="text-muted-foreground">—</span>
+        }
+        return (
+          <div className="flex flex-wrap gap-1 max-w-[200px]">
+            {tags.slice(0, 3).map(tag => (
+              <Badge key={tag} variant="secondary" className="text-xs">{tag}</Badge>
+            ))}
+            {tags.length > 3 && (
+              <Badge variant="outline" className="text-xs" title={tags.slice(3).join(", ")}>
+                +{tags.length - 3}
+              </Badge>
+            )}
+          </div>
+        )
+      },
+    },
+    {
       accessorKey: "status",
       header: ({ column }) => {
         return (
@@ -691,6 +770,14 @@ export default function ProxiesPage() {
                   <DropdownMenuItem onClick={() => setIsImportDialogOpen(true)}>
                     <Upload className="mr-2 h-4 w-4" />
                     Import from TXT
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={() => setIsTagDialogOpen(true)}
+                    disabled={Object.keys(rowSelection).length === 0}
+                  >
+                    <Tag className="mr-2 h-4 w-4" />
+                    Edit tags of selected ({Object.keys(rowSelection).length})
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem onClick={() => handleExport("txt")}>
@@ -958,6 +1045,18 @@ export default function ProxiesPage() {
                 onChange={(e) => setNewProxy({ ...newProxy, password: e.target.value })}
               />
             </div>
+            <div className="grid gap-2">
+              <Label htmlFor="tags">Tags (optional)</Label>
+              <TagInput
+                id="tags"
+                value={newProxy.tags}
+                onChange={(tags) => setNewProxy({ ...newProxy, tags })}
+                suggestions={allTags}
+              />
+              <p className="text-xs text-muted-foreground">
+                Tags let pools match proxies without GeoIP data (e.g. local/VPN proxies)
+              </p>
+            </div>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setIsAddDialogOpen(false)}>
@@ -1017,6 +1116,15 @@ export default function ProxiesPage() {
                   onChange={(e) => setEditingProxy({ ...editingProxy, username: e.target.value })}
                 />
               </div>
+              <div className="grid gap-2">
+                <Label htmlFor="edit-tags">Tags</Label>
+                <TagInput
+                  id="edit-tags"
+                  value={editingProxy.tags ?? []}
+                  onChange={(tags) => setEditingProxy({ ...editingProxy, tags })}
+                  suggestions={allTags}
+                />
+              </div>
             </div>
           )}
           <DialogFooter>
@@ -1025,6 +1133,55 @@ export default function ProxiesPage() {
             </Button>
             <Button onClick={handleEditProxy}>
               Save Changes
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Bulk Tag Dialog */}
+      <Dialog open={isTagDialogOpen} onOpenChange={(open) => {
+        setIsTagDialogOpen(open)
+        if (!open) {
+          setBulkAddTags([])
+          setBulkRemoveTags([])
+        }
+      }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit tags of {Object.keys(rowSelection).length} proxies</DialogTitle>
+            <DialogDescription>
+              Added tags are appended to each proxy&apos;s existing tags; removed tags are stripped.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="bulk-add-tags">Add tags</Label>
+              <TagInput
+                id="bulk-add-tags"
+                value={bulkAddTags}
+                onChange={setBulkAddTags}
+                suggestions={allTags}
+                disabled={isTagging}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="bulk-remove-tags">Remove tags</Label>
+              <TagInput
+                id="bulk-remove-tags"
+                value={bulkRemoveTags}
+                onChange={setBulkRemoveTags}
+                suggestions={allTags}
+                disabled={isTagging}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsTagDialogOpen(false)} disabled={isTagging}>
+              Cancel
+            </Button>
+            <Button onClick={handleBulkTag} disabled={isTagging}>
+              {isTagging && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Apply Tags
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/dashboard/components/tag-input.tsx
+++ b/dashboard/components/tag-input.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import * as React from "react"
+import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+
+interface TagInputProps {
+  value: string[]
+  onChange: (tags: string[]) => void
+  /** Known tags shown as one-click suggestions (already-added ones are hidden) */
+  suggestions?: string[]
+  placeholder?: string
+  disabled?: boolean
+  id?: string
+}
+
+// Chips-style tag editor: Enter/comma adds, × or Backspace on empty removes.
+export function TagInput({
+  value,
+  onChange,
+  suggestions = [],
+  placeholder = "Add tag…",
+  disabled,
+  id,
+}: TagInputProps) {
+  const [draft, setDraft] = React.useState("")
+
+  const addTag = (raw: string) => {
+    const tag = raw.trim()
+    if (!tag || value.includes(tag)) return
+    onChange([...value, tag])
+  }
+
+  const removeTag = (tag: string) => onChange(value.filter(t => t !== tag))
+
+  const commitDraft = () => {
+    if (draft.trim()) {
+      addTag(draft)
+      setDraft("")
+    }
+  }
+
+  const available = suggestions.filter(s => !value.includes(s))
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex flex-wrap gap-1.5 min-h-[28px]">
+        {value.length === 0 && (
+          <span className="text-xs text-muted-foreground italic">No tags</span>
+        )}
+        {value.map(tag => (
+          <Badge key={tag} variant="secondary" className="gap-1 pr-1">
+            <span className="text-xs">{tag}</span>
+            <button
+              type="button"
+              className="ml-0.5 rounded hover:bg-muted-foreground/20 px-1 text-xs leading-none"
+              onClick={() => removeTag(tag)}
+              disabled={disabled}
+              title="Remove"
+            >
+              ×
+            </button>
+          </Badge>
+        ))}
+      </div>
+      <Input
+        id={id}
+        value={draft}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={e => setDraft(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === "Enter" || e.key === ",") {
+            e.preventDefault()
+            commitDraft()
+          } else if (e.key === "Backspace" && !draft && value.length > 0) {
+            removeTag(value[value.length - 1])
+          }
+        }}
+        onBlur={commitDraft}
+      />
+      {available.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {available.slice(0, 12).map(s => (
+            <Button
+              key={s}
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={disabled}
+              className="h-6 px-2 text-xs"
+              onClick={() => addTag(s)}
+            >
+              {s}
+            </Button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -11,6 +11,7 @@ import {
   UpdateProxyRequest,
   BulkProxyRequest,
   BulkDeleteRequest,
+  BulkTagRequest,
   ProxyTestResult,
   ProxySource,
   CreateSourceRequest,
@@ -213,6 +214,16 @@ class ApiClient {
     message: string
   }> {
     return this.request("/api/v1/proxies/bulk-delete", {
+      method: "POST",
+      body: JSON.stringify(request),
+    })
+  }
+
+  async bulkTagProxies(request: BulkTagRequest): Promise<{
+    updated: number
+    message: string
+  }> {
+    return this.request("/api/v1/proxies/bulk-tags", {
       method: "POST",
       body: JSON.stringify(request),
     })

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -10,6 +10,7 @@ export interface Proxy {
   avg_response_time: number
   last_check: string
   username?: string
+  tags: string[]
   created_at: string
   updated_at: string
 }
@@ -160,6 +161,7 @@ export interface AddProxyRequest {
   protocol: "http" | "https" | "socks4" | "socks4a" | "socks5"
   username?: string
   password?: string
+  tags?: string[]
 }
 
 export interface UpdateProxyRequest {
@@ -167,6 +169,13 @@ export interface UpdateProxyRequest {
   protocol?: "http" | "https" | "socks4" | "socks4a" | "socks5"
   username?: string
   password?: string
+  tags?: string[]
+}
+
+export interface BulkTagRequest {
+  ids: number[]
+  add?: string[]
+  remove?: string[]
 }
 
 export interface BulkProxyRequest {


### PR DESCRIPTION
## Summary
Fixes #45 — local/VPN proxies (RFC1918, no GeoIP data) could not be added to any pool because the dashboard only exposed country filters, even though the backend fully supports tags, tag/ISP pool filters and manual membership.

### Dashboard
- **Proxy Management**: new Tags column, tag editing in the add/edit dialogs (chips input with suggestions from `/pools/tag-list`), and a bulk **Edit tags of selected** action
- **Pool create/edit dialog**: new **Tag filters** (AND logic) and **ISP filters** (OR, substring) sections; fixed the misleading "no country filters — this pool will not sync any proxies" copy
- **Pool detail**: **Add Proxies** picker (search + multi-select) and per-row remove, wired to the existing `POST/DELETE /pools/{id}/proxies` endpoints that the UI never used; shows a warning when the pool is in auto sync mode (sync rebuilds membership from filters)

### Core
- New `POST /api/v1/proxies/bulk-tags` endpoint (`{ids, add, remove}`) — updates tags on many proxies in one statement. Per-proxy `PUT`s were not an option because that endpoint replaces credentials wholesale
- **Fix**: proxy update now preserves the stored password when the request omits it (`nil` = keep, `""` = clear). Previously *any* edit from the dashboard silently wiped the proxy's password, since the password is never round-tripped to clients
- swagger.json: documented the new endpoint (hand-edited, matching how the pool endpoints are documented — the file is not fully regenerable from annotations)

## Test plan
- `go build ./...`, `go vet`, `go test ./...` green
- `npx tsc --noEmit` clean; `pnpm build` succeeds; ESLint identical to main (no new findings)
- Manual flow for #45: add proxies → tag them (bulk or single) → create pool with only a tag filter → Sync populates the pool; or skip tags entirely and use the new Add Proxies picker with manual sync mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)