### PR TITLE
fix: map proxy port to the port the core actually binds to

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,8 @@ services:
     ports:
       # The proxy itself is the product — keep it reachable on the host.
       # The REST API (8001) is internal only; reach it via Caddy at /api.
-      - "${PROXY_PORT:-8000}:8000"
+      # The container-side port must match PROXY_PORT (the core binds to it).
+      - "${PROXY_PORT:-8000}:${PROXY_PORT:-8000}"
     environment:
       - PROXY_PORT=${PROXY_PORT:-8000}
       - API_PORT=8001


### PR DESCRIPTION
## Problem

Starting Rota with a non-default `PROXY_PORT` (e.g. `PROXY_PORT=8003`) broke the proxy:

```
$ curl -x http://rotate:rotate@localhost:8003 http://ip.me
curl: (56) Recv failure: Connection reset by peer
```

## Root cause

`docker-compose.yml` hardcoded the container-side port of the proxy mapping to `8000`:

```yaml
ports:
  - "${PROXY_PORT:-8000}:8000"
```

while also passing `PROXY_PORT` as an env var. The Go core binds to `PROXY_PORT` *inside* the container:

```go
httpServer := &http.Server{ Addr: fmt.Sprintf(":%d", port) } // port = cfg.ProxyPort
```

So with `PROXY_PORT=8003` the proxy server listens on `:8003` inside the container, but Docker forwarded `host:8003 -> container:8000`, where nothing was listening. The result is a TCP RST and zero proxy logs (the proxy never sees the traffic).

## Fix

Use `PROXY_PORT` for both sides of the mapping so host and container ports stay in sync:

```yaml
ports:
  - "${PROXY_PORT:-8000}:${PROXY_PORT:-8000}"
```

## Verification

```
$ curl -sS -x http://rotate:rotate@localhost:8003 http://ip.me
194.67.218.197          # HTTP 200

$ curl -sS -x http://rotate:rotate@localhost:8003 https://api.ipify.org
194.67.220.45           # HTTP 200 (CONNECT tunnel)
```

Core logs show the pool chain is now rotating correctly:

```
pool chain: trying proxy   proxy=194.67.218.197:9260  → success 200
pool chain CONNECT: trying proxy  194.67.220.45:9933  → success
```